### PR TITLE
Enhance API, update dependencies, and improve documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,3 +100,7 @@ ENV/
 .ruff_cache/
 
 uv.lock
+
+# Claude code
+CLAUDE.local.md
+.claude/settings.local.json

--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,4 +1,104 @@
-/* https://stackoverflow.com/questions/56195758/different-maxdepth-for-specific-entries-in-toctree-sphinx */
-.rst-content .toctree-wrapper:not(:last-child) ul {
-    margin-bottom: 12px;
- }
+/* Layout tweaks */
+.wy-nav-content {
+    max-width: 1200px !important;
+}
+
+/* Make wide tables readable on desktop */
+@media screen and (min-width: 767px) {
+    .wy-table-responsive table td {
+        /* Prevent later stylesheets from re-wrapping cells */
+        white-space: normal !important;
+    }
+
+    .wy-table-responsive {
+        overflow: visible !important;
+    }
+}
+
+/* Hide the hash icon that appears on hover in headings */
+.headerlink::after {
+    font-size: 0;
+}
+
+/* Call attention to API signatures */
+dl.py.function dt,
+dl.py.class dt,
+dl.py.method dt {
+    background: #f8f8f8;
+    padding: 8px;
+}
+
+/* Paragraph readability */
+.wy-nav-content p {
+    line-height: 1.5;
+}
+
+/* Cleaner parameter/field lists */
+.rst-content dl.field-list {
+    display: grid;
+    grid-template-columns: max-content 1fr;
+    gap: 0 1em;
+    align-items: baseline;
+}
+
+.rst-content dl.field-list > dd {
+    align-self: center;
+}
+
+/* Emphasize parameter names */
+.rst-content dl.field-list dt {
+    font-weight: 600;
+    color: #555;
+}
+
+/* Signature parameter styling */
+.rst-content .sig-param .n {
+    color: #333;
+}
+
+.rst-content .sig-param .default_value {
+    color: #666;
+}
+
+/* Link styling */
+.rst-content a {
+    color: #2980b9;
+}
+
+.rst-content a:hover {
+    color: #1a5276;
+}
+
+/* Tighter list spacing inside field-list items */
+.rst-content dl.field-list dd ul li > p,
+.rst-content dl.field-list dd ul li > ul {
+    margin-top: 0 !important;
+    margin-bottom: 0 !important;
+}
+
+/* Highlight the current page in the sidebar */
+.wy-menu-vertical li.current > a {
+    background: #fcfcfc;
+    border-left: 3px solid #2980b9;
+}
+
+/* Inline code styling */
+.rst-content code.literal {
+    background: #f0f0f0;
+    padding: 2px 4px;
+    border-radius: 3px;
+    border: none;
+    font-size: 85%;
+}
+
+/* Code block styling */
+.rst-content div[class^="highlight"] {
+    background: #f8f8f8;
+    border-radius: 4px;
+}
+
+.rst-content div[class^="highlight"] pre {
+    font-size: 13px;
+    line-height: 1.5;
+    border-radius: 4px;
+}

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -55,13 +55,31 @@ Support functions
 
 .. _ref_images:
 
-:mod:`neuromaps_mouse.images` - Image and surface handling
-----------------------------------------------------------
+:mod:`neuromaps_mouse.images` - Image processing
+-------------------------------------------------
 .. automodule:: neuromaps_mouse.images
    :no-members:
    :no-inherited-members:
 
 .. currentmodule:: neuromaps_mouse.images
+
+.. autosummary::
+   :template: function.rst
+   :toctree: generated/
+
+   parcellate_image
+   register_image
+   transform_image
+
+.. _ref_io:
+
+:mod:`neuromaps_mouse.io` - Image and surface handling
+------------------------------------------------------
+.. automodule:: neuromaps_mouse.io
+   :no-members:
+   :no-inherited-members:
+
+.. currentmodule:: neuromaps_mouse.io
 
 Functions to load the images and surfaces
 
@@ -91,15 +109,15 @@ Functions to load the images and surfaces
    plot_allenccfv3_lightbox
    plot_allenccfv3_3d
 
-.. _ref_resampling:
+.. _ref_regions:
 
-:mod:`neuromaps_mouse.resampling` - Resampling workflows
---------------------------------------------------------
-.. automodule:: neuromaps_mouse.resampling
+:mod:`neuromaps_mouse.regions` - Region queries and alignment
+-------------------------------------------------------------
+.. automodule:: neuromaps_mouse.regions
     :no-members:
     :no-inherited-members:
 
-.. currentmodule:: neuromaps_mouse.resampling
+.. currentmodule:: neuromaps_mouse.regions
 
 .. autosummary::
     :template: function.rst
@@ -126,19 +144,5 @@ Functions to load the images and surfaces
     :toctree: generated/
 
     correlation
+    moran
 
-.. _ref_transforms:
-
-:mod:`neuromaps_mouse.transforms` - Transformations between spaces
-------------------------------------------------------------------
-.. automodule:: neuromaps_mouse.transforms
-   :no-members:
-   :no-inherited-members:
-
-.. currentmodule:: neuromaps_mouse.transforms
-
-.. autosummary::
-   :template: function.rst
-   :toctree: generated/
-
-   allenccfv3_to_allenccfv3

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -9,4 +9,61 @@ Installation and setup
 Requirements
 ============
 
-TBD
+This package requires Python >= 3.8.
+
+.. _installation_basic:
+
+Basic installation
+==================
+
+Assuming you have the correct version of Python installed, you can install
+`neuromaps-mouse` by opening a terminal and running the following:
+
+.. code-block:: bash
+
+   git clone https://github.com/netneurolab/neuromaps-mouse.git
+   cd neuromaps-mouse
+   pip install .
+
+.. _installation_optional:
+
+Optional dependencies
+=====================
+
+Some functionality in neuromaps-mouse requires additional dependencies.
+
+Pyvista
+-------
+
+Pyvista is the plotting library used in the package for 3D surface visualization.
+This will allow you to use functions like
+
+* :func:`neuromaps_mouse.plotting.plot_allenccfv3_3d`
+
+You will need a working Pyvista installation. We recommend using a clean conda
+environment and installing Pyvista using the following commands:
+
+.. code-block:: bash
+
+   conda create -n plotting python=3.12
+   conda activate plotting
+   conda install -c conda-forge pyvista
+
+Pyvista is actively maintained and generally installs without issues. Please
+also check out their `detailed installation guide <https://docs.pyvista.org/getting-started/installation.html>`_.
+
+Pyvista is built on top of VTK, which supports multiple OpenGL window backends
+and you can choose one that fits your environment (see the `VTK runtime settings <https://docs.vtk.org/en/latest/advanced/runtime_settings.html>`_):
+
+* **X11**: standard Linux display server (requires an active X server)
+* **Win32**: native Windows OpenGL context
+* **EGL**: offscreen GPU context (good for headless servers with GPUs)
+* **OSMesa**: CPU-based software rendering (good for headless servers without GPUs)
+
+For example, on a headless Linux server without a GPU you can request OSMesa by
+setting the backend before importing PyVista/VTK:
+
+.. code-block:: python
+
+   import os
+   os.environ["VTK_DEFAULT_OPENGL_WINDOW"] = "vtkOSOpenGLRenderWindow"

--- a/docs/listofmaps.rst
+++ b/docs/listofmaps.rst
@@ -3,1402 +3,764 @@
 ------------
 List of Maps
 ------------
-This is a complete list of maps available in the `neuromaps_mouse` package. 
+This is a complete list of maps available in the `neuromaps_mouse` package.
 
 ----
 
-synaptome (zhu2018)
-===================
+Psychedelic drug activation maps (aboharb2025)
+==============================================
 
-**Full description**
+Regional brain activation maps following administration of various
+psychedelic compounds and controls, measured via whole-brain imaging.
 
-Architecture of the Mouse Brain Synaptome
+Each file contains activation values for a single treatment condition:
+psychedelics (5-MeO, 6-F-DET, Ketamine, MDMA, Psilocybin),
+antidepressant controls (ASSRI, CSSRI), and saline control.
 
-zhu2018-typedensity-allenccfv3-region
--------------------------------------
+**Available files**
 
-**Description**: Synaptic type density
+.. list-table::
+   :header-rows: 1
 
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('zhu2018', 'typedensity', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/zhu2018
-
-    # file name
-    # source-zhu2018_desc-typedensity_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-zhu2018_regionmapping.csv
-
-**References**
-
-----
-
-structural connectome (oh2014)
-==============================
-
-**Full description**
-
-A mesoscale connectome of the mouse brain
-
-oh2014-wipsi-allenccfv3-region
-------------------------------
-
-**Description**: Weighted ipsilateral strength index
-
-**Format**: matrix
+   * - Description
+     - Format
+     - Key
+   * - 5-MeO
+     - tabular
+     - ``('aboharb2025', '5meo', 'allenccfv3', 'region')``
+   * - 6-F-DET
+     - tabular
+     - ``('aboharb2025', '6fdet', 'allenccfv3', 'region')``
+   * - ASSRI
+     - tabular
+     - ``('aboharb2025', 'assri', 'allenccfv3', 'region')``
+   * - CSSRI
+     - tabular
+     - ``('aboharb2025', 'cssri', 'allenccfv3', 'region')``
+   * - Ketamine
+     - tabular
+     - ``('aboharb2025', 'ket', 'allenccfv3', 'region')``
+   * - MDMA
+     - tabular
+     - ``('aboharb2025', 'mdma', 'allenccfv3', 'region')``
+   * - Psilocybin
+     - tabular
+     - ``('aboharb2025', 'psi', 'allenccfv3', 'region')``
+   * - Saline
+     - tabular
+     - ``('aboharb2025', 'sal', 'allenccfv3', 'region')``
 
 **How to use**
 
 .. code:: python
 
-    # get annotation
-    fetch_annotation(('oh2014', 'wipsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/oh2014
-
-    # file name
-    # source-oh2014_desc-wipsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-oh2014_regionmapping.csv
-
-oh2014-pvalipsi-allenccfv3-region
----------------------------------
-
-**Description**: P values for wipsi
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('oh2014', 'pvalipsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/oh2014
-
-    # file name
-    # source-oh2014_desc-pvalipsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-oh2014_regionmapping.csv
-
-oh2014-wcontra-allenccfv3-region
---------------------------------
-
-**Description**: Weighted contralateral strength index
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('oh2014', 'wcontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/oh2014
-
-    # file name
-    # source-oh2014_desc-wcontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-oh2014_regionmapping.csv
-
-oh2014-pvalcontra-allenccfv3-region
------------------------------------
-
-**Description**: P values for wcontra
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('oh2014', 'pvalcontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/oh2014
-
-    # file name
-    # source-oh2014_desc-pvalcontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-oh2014_regionmapping.csv
-
-oh2014-distipsi-allenccfv3-region
----------------------------------
-
-**Description**: Distance (mm) for ipsilateral projections
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('oh2014', 'distipsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/oh2014
-
-    # file name
-    # source-oh2014_desc-distipsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-oh2014_regionmapping.csv
-
-oh2014-distcontra-allenccfv3-region
------------------------------------
-
-**Description**: Distance (mm) for contralateral projections
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('oh2014', 'distcontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/oh2014
-
-    # file name
-    # source-oh2014_desc-distcontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-oh2014_regionmapping.csv
-
-**References**
-
-----
-
-cell type density (ero2018)
-===========================
-
-**Full description**
-
-A Cell Atlas for the Mouse Brain
-
-ero2018-celldensity-allenccfv3-region
--------------------------------------
-
-**Description**: Density of cell types
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('ero2018', 'celldensity', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/ero2018
-
-    # file name
-    # source-ero2018_desc-celldensity_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-ero2018_regionmapping.csv
-
-**References**
-
-----
-
-Allen Mouse Brain Atlas (lein2006amba)
-======================================
-
-**Full description**
-
-Allen Mouse Brain Atlas
-
-lein2006amba-sagittalenergy-allenccfv3-region
----------------------------------------------
-
-**Description**: Expression energy of sagittal slices
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('lein2006amba', 'sagittalenergy', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/lein2006amba
-
-    # file name
-    # source-lein2006amba_desc-sagittalenergy_space-allenccfv3_res-region_tabular.csv.gz
-
-    # region mapping file
-    # source-lein2006amba_regionmapping.csv
-
-lein2006amba-coronalenergy-allenccfv3-region
---------------------------------------------
-
-**Description**: Expression energy of coronal slices
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('lein2006amba', 'coronalenergy', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/lein2006amba
-
-    # file name
-    # source-lein2006amba_desc-coronalenergy_space-allenccfv3_res-region_tabular.csv.gz
-
-    # region mapping file
-    # source-lein2006amba_regionmapping.csv
-
-lein2006amba-sagittaldensity-allenccfv3-region
-----------------------------------------------
-
-**Description**: Expression density of sagittal slices
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('lein2006amba', 'sagittaldensity', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/lein2006amba
-
-    # file name
-    # source-lein2006amba_desc-sagittaldensity_space-allenccfv3_res-region_tabular.csv.gz
-
-    # region mapping file
-    # source-lein2006amba_regionmapping.csv
-
-lein2006amba-coronaldensity-allenccfv3-region
----------------------------------------------
-
-**Description**: Expression density of coronal slices
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('lein2006amba', 'coronaldensity', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/lein2006amba
-
-    # file name
-    # source-lein2006amba_desc-coronaldensity_space-allenccfv3_res-region_tabular.csv.gz
-
-    # region mapping file
-    # source-lein2006amba_regionmapping.csv
-
-lein2006amba-sagittalintensity-allenccfv3-region
-------------------------------------------------
-
-**Description**: Expression intensity of sagittal slices
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('lein2006amba', 'sagittalintensity', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/lein2006amba
-
-    # file name
-    # source-lein2006amba_desc-sagittalintensity_space-allenccfv3_res-region_tabular.csv.gz
-
-    # region mapping file
-    # source-lein2006amba_regionmapping.csv
-
-lein2006amba-coronalintensity-allenccfv3-region
------------------------------------------------
-
-**Description**: Expression intensity of coronal slices
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('lein2006amba', 'coronalintensity', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/lein2006amba
-
-    # file name
-    # source-lein2006amba_desc-coronalintensity_space-allenccfv3_res-region_tabular.csv.gz
-
-    # region mapping file
-    # source-lein2006amba_regionmapping.csv
-
-**References**
-
-----
-
-ABC Atlas (MERFISH-C57BL6J-638850) (yao2023abca)
-================================================
-
-**Full description**
-
-Mouse whole-brain transcriptomic cell type atlas (Hongkui Zeng)
-
-yao2023abca-divimean-allenccfv3-region
---------------------------------------
-
-**Description**: Average regional gene expressions at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'divimean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-divimean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_division_regionmapping.csv
-
-yao2023abca-strumean-allenccfv3-region
---------------------------------------
-
-**Description**: Average regional gene expressions at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'strumean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-strumean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_structure_regionmapping.csv
-
-yao2023abca-subsmean-allenccfv3-region
---------------------------------------
-
-**Description**: Average regional gene expressions at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'subsmean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-subsmean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_substructure_regionmapping.csv
-
-yao2023abca-impdivimean-allenccfv3-region
------------------------------------------
-
-**Description**: Average imputed regional gene expressions at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'impdivimean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-impdivimean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_division_regionmapping.csv
-
-yao2023abca-impstrumean-allenccfv3-region
------------------------------------------
-
-**Description**: Average imputed regional gene expressions at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'impstrumean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-impstrumean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_structure_regionmapping.csv
-
-yao2023abca-impsubsmean-allenccfv3-region
------------------------------------------
-
-**Description**: Average imputed regional gene expressions at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'impsubsmean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-impsubsmean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_substructure_regionmapping.csv
-
-yao2023abca-divictclass-allenccfv3-region
------------------------------------------
-
-**Description**: Cell type (class) at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'divictclass', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-divictclass_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_division_regionmapping.csv
-
-yao2023abca-structclass-allenccfv3-region
------------------------------------------
-
-**Description**: Cell type (class) at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'structclass', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-structclass_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_structure_regionmapping.csv
-
-yao2023abca-subsctclass-allenccfv3-region
------------------------------------------
-
-**Description**: Cell type (class) at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'subsctclass', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-subsctclass_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_substructure_regionmapping.csv
-
-yao2023abca-divictsubclass-allenccfv3-region
---------------------------------------------
-
-**Description**: Cell type (subclass) at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'divictsubclass', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-divictsubclass_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_division_regionmapping.csv
-
-yao2023abca-structsubclass-allenccfv3-region
---------------------------------------------
-
-**Description**: Cell type (subclass) at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'structsubclass', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-structsubclass_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_structure_regionmapping.csv
-
-yao2023abca-subsctsubclass-allenccfv3-region
---------------------------------------------
-
-**Description**: Cell type (subclass) at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'subsctsubclass', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-subsctsubclass_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_substructure_regionmapping.csv
-
-yao2023abca-divictsupertype-allenccfv3-region
----------------------------------------------
-
-**Description**: Cell type (supertype) at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'divictsupertype', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-divictsupertype_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_division_regionmapping.csv
-
-yao2023abca-structsupertype-allenccfv3-region
----------------------------------------------
-
-**Description**: Cell type (supertype) at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'structsupertype', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-structsupertype_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_structure_regionmapping.csv
-
-yao2023abca-subsctsupertype-allenccfv3-region
----------------------------------------------
-
-**Description**: Cell type (supertype) at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'subsctsupertype', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-subsctsupertype_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_substructure_regionmapping.csv
-
-yao2023abca-divictcluster-allenccfv3-region
--------------------------------------------
-
-**Description**: Cell type (cluster) at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'divictcluster', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-divictcluster_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_division_regionmapping.csv
-
-yao2023abca-structcluster-allenccfv3-region
--------------------------------------------
-
-**Description**: Cell type (cluster) at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'structcluster', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-structcluster_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_structure_regionmapping.csv
-
-yao2023abca-subsctcluster-allenccfv3-region
--------------------------------------------
-
-**Description**: Cell type (cluster) at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('yao2023abca', 'subsctcluster', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/yao2023abca
-
-    # file name
-    # source-yao2023abca_desc-subsctcluster_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-yao2023abca_substructure_regionmapping.csv
-
-**References**
-
-----
-
-ABC Atlas (Zhuang-ABCA) (zhang2023abca)
-=======================================
-
-**Full description**
-
-A molecularly defined and spatially resolved cell atlas of the whole mouse brain (Xiaowei Zhuang)
-
-zhang2023abca-divimean-allenccfv3-region
-----------------------------------------
-
-**Description**: Average regional gene expressions at the division level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('zhang2023abca', 'divimean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/zhang2023abca
-
-    # file name
-    # source-zhang2023abca_desc-divimean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-zhang2023abca_division_regionmapping.csv
-
-zhang2023abca-strumean-allenccfv3-region
-----------------------------------------
-
-**Description**: Average regional gene expressions at the structure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('zhang2023abca', 'strumean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/zhang2023abca
-
-    # file name
-    # source-zhang2023abca_desc-strumean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-zhang2023abca_structure_regionmapping.csv
-
-zhang2023abca-subsmean-allenccfv3-region
-----------------------------------------
-
-**Description**: Average regional gene expressions at the substructure level
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('zhang2023abca', 'subsmean', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/zhang2023abca
-
-    # file name
-    # source-zhang2023abca_desc-subsmean_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-zhang2023abca_substructure_regionmapping.csv
-
-**References**
-
-----
-
-hi-res connectome (knox2018)
-============================
-
-**Full description**
-
- High-resolution data-driven model of the mouse connectome
-
-knox2018-conndencontra-allenccfv3-region
-----------------------------------------
-
-**Description**: Connection density (contralateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'conndencontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-conndencontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-conndenipsi-allenccfv3-region
---------------------------------------
-
-**Description**: Connection density (ipsilateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'conndenipsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-conndenipsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-connstrcontra-allenccfv3-region
-----------------------------------------
-
-**Description**: Connection strength (contralateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'connstrcontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-connstrcontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-connstripsi-allenccfv3-region
---------------------------------------
-
-**Description**: Connection strength (ipsilateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'connstripsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-connstripsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-normconndencontra-allenccfv3-region
---------------------------------------------
-
-**Description**: Normalized connection density (contralateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'normconndencontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-normconndencontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-normconndenipsi-allenccfv3-region
-------------------------------------------
-
-**Description**: Normalized connection density (ipsilateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'normconndenipsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-normconndenipsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-normconnstrcontra-allenccfv3-region
---------------------------------------------
-
-**Description**: Normalized connection strength (contralateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'normconnstrcontra', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-normconnstrcontra_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-knox2018-normconnstripsi-allenccfv3-region
-------------------------------------------
-
-**Description**: Normalized connection strength (ipsilateral)
-
-**Format**: matrix
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('knox2018', 'normconnstripsi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/knox2018
-
-    # file name
-    # source-knox2018_desc-normconnstripsi_space-allenccfv3_res-region_matrix.csv
-
-    # region mapping file
-    # source-knox2018_regionmapping.csv
-
-**References**
-
-----
-
-aboharb2025 (aboharb2025)
-=========================
-
-**Full description**
-
-
-
-aboharb2025-5meo-allenccfv3-region
-----------------------------------
-
-**Description**: 5-MeO
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
+    # fetch a specific annotation
     fetch_annotation(('aboharb2025', '5meo', 'allenccfv3', 'region'))
 
     # file location
     # $MOUSEMAPS_DATA/aboharb2025
 
-    # file name
-    # source-aboharb2025_desc-5meo_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
+    # region mapping files
     # source-aboharb2025_regionmapping.csv
 
-aboharb2025-6fdet-allenccfv3-region
------------------------------------
-
-**Description**: 6-F-DET
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', '6fdet', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-6fdet_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-aboharb2025-assri-allenccfv3-region
------------------------------------
-
-**Description**: ASSRI
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', 'assri', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-assri_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-aboharb2025-cssri-allenccfv3-region
------------------------------------
-
-**Description**: CSSRI
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', 'cssri', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-cssri_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-aboharb2025-ket-allenccfv3-region
----------------------------------
-
-**Description**: Ketamine
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', 'ket', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-ket_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-aboharb2025-mdma-allenccfv3-region
-----------------------------------
-
-**Description**: MDMA
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', 'mdma', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-mdma_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-aboharb2025-psi-allenccfv3-region
----------------------------------
-
-**Description**: Psilocybin
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', 'psi', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-psi_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-aboharb2025-sal-allenccfv3-region
----------------------------------
-
-**Description**: Saline
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('aboharb2025', 'sal', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/aboharb2025
-
-    # file name
-    # source-aboharb2025_desc-sal_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-aboharb2025_regionmapping.csv
-
-**References**
 
 ----
 
-ibl2025 (ibl2025)
-=================
+Cell type density atlas (ero2018)
+=================================
 
-**Full description**
+A Cell Atlas for the Mouse Brain (Ero et al., 2018).
 
+Provides density estimates of major cell types across
+Allen CCFv3 brain regions, derived from single-cell RNA sequencing
+and in situ hybridization data.
 
+**Available files**
 
-ibl2025-behtask-allenccfv3-region
----------------------------------
+.. list-table::
+   :header-rows: 1
 
-**Description**: Behavioral task
-
-**Format**: tabular
+   * - Description
+     - Format
+     - Key
+   * - Density of cell types
+     - tabular
+     - ``('ero2018', 'celldensity', 'allenccfv3', 'region')``
 
 **How to use**
 
 .. code:: python
 
-    # get annotation
+    # fetch a specific annotation
+    fetch_annotation(('ero2018', 'celldensity', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/ero2018
+
+    # region mapping files
+    # source-ero2018_regionmapping.csv
+
+
+----
+
+IBL behavioral and electrophysiology maps (ibl2025)
+===================================================
+
+Regional brain maps from the International Brain Laboratory (IBL)
+reproducible brain-wide mapping pipeline.
+
+Includes behavioral task performance metrics and electrophysiology
+summary statistics mapped to Allen CCFv3 regions.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Behavioral task
+     - tabular
+     - ``('ibl2025', 'behtask', 'allenccfv3', 'region')``
+   * - Electrophysiology
+     - tabular
+     - ``('ibl2025', 'ephys', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
     fetch_annotation(('ibl2025', 'behtask', 'allenccfv3', 'region'))
 
     # file location
     # $MOUSEMAPS_DATA/ibl2025
 
-    # file name
-    # source-ibl2025_desc-behtask_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
+    # region mapping files
     # source-ibl2025_regionmapping.csv
 
-ibl2025-ephys-allenccfv3-region
--------------------------------
-
-**Description**: Electrophysiology
-
-**Format**: tabular
-
-**How to use**
-
-.. code:: python
-
-    # get annotation
-    fetch_annotation(('ibl2025', 'ephys', 'allenccfv3', 'region'))
-
-    # file location
-    # $MOUSEMAPS_DATA/ibl2025
-
-    # file name
-    # source-ibl2025_desc-ephys_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
-    # source-ibl2025_regionmapping.csv
-
-**References**
 
 ----
 
-ji2021 (ji2021)
-===============
+Brain microvasculature (ji2021)
+===============================
 
-**Full description**
+Brain microvasculature has a common topology with local differences
+in geometry that match metabolic load (Ji et al., 2021).
 
+Whole mouse brain microvasculature imaged, reconstructed,
+and analyzed at sub-micrometer resolution. Includes data from
+Ji et al. (2021), Kirst et al. (2020), and Todorov et al. (2020).
 
+Each file contains region-level tabular data characterizing
+microvascular network properties across Allen CCFv3 regions.
 
-ji2021-ji2021-allenccfv3-region
--------------------------------
+**Available files**
 
-**Description**: Ji 2021
+.. list-table::
+   :header-rows: 1
 
-**Format**: tabular
+   * - Description
+     - Format
+     - Key
+   * - Ji 2021
+     - tabular
+     - ``('ji2021', 'ji2021', 'allenccfv3', 'region')``
+   * - Kirst 2020
+     - tabular
+     - ``('ji2021', 'kirst2020', 'allenccfv3', 'region')``
+   * - Todorov 2020
+     - tabular
+     - ``('ji2021', 'todorov2020', 'allenccfv3', 'region')``
 
 **How to use**
 
 .. code:: python
 
-    # get annotation
+    # fetch a specific annotation
     fetch_annotation(('ji2021', 'ji2021', 'allenccfv3', 'region'))
 
     # file location
     # $MOUSEMAPS_DATA/ji2021
 
-    # file name
-    # source-ji2021_desc-ji2021_space-allenccfv3_res-region_tabular.csv
-
-    # region mapping file
+    # region mapping files
     # source-ji2021_regionmapping.csv
 
-ji2021-kirst2020-allenccfv3-region
-----------------------------------
 
-**Description**: Kirst 2020
+----
 
-**Format**: tabular
+High-resolution connectome model (knox2018)
+===========================================
+
+A high-resolution data-driven model of the mouse connectome
+(Knox et al., 2018).
+
+Provides region-by-region connectivity matrices at the Allen CCFv3
+parcellation. Each matrix is asymmetric: rows are source regions and
+columns are target regions. Available for both ipsi- and contralateral
+projections, in connection density and connection strength variants,
+each with normalized versions.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Connection density (contralateral)
+     - matrix
+     - ``('knox2018', 'conndencontra', 'allenccfv3', 'region')``
+   * - Connection density (ipsilateral)
+     - matrix
+     - ``('knox2018', 'conndenipsi', 'allenccfv3', 'region')``
+   * - Connection strength (contralateral)
+     - matrix
+     - ``('knox2018', 'connstrcontra', 'allenccfv3', 'region')``
+   * - Connection strength (ipsilateral)
+     - matrix
+     - ``('knox2018', 'connstripsi', 'allenccfv3', 'region')``
+   * - Normalized connection density (contralateral)
+     - matrix
+     - ``('knox2018', 'normconndencontra', 'allenccfv3', 'region')``
+   * - Normalized connection density (ipsilateral)
+     - matrix
+     - ``('knox2018', 'normconndenipsi', 'allenccfv3', 'region')``
+   * - Normalized connection strength (contralateral)
+     - matrix
+     - ``('knox2018', 'normconnstrcontra', 'allenccfv3', 'region')``
+   * - Normalized connection strength (ipsilateral)
+     - matrix
+     - ``('knox2018', 'normconnstripsi', 'allenccfv3', 'region')``
 
 **How to use**
 
 .. code:: python
 
-    # get annotation
-    fetch_annotation(('ji2021', 'kirst2020', 'allenccfv3', 'region'))
+    # fetch a specific annotation
+    fetch_annotation(('knox2018', 'conndencontra', 'allenccfv3', 'region'))
 
     # file location
-    # $MOUSEMAPS_DATA/ji2021
+    # $MOUSEMAPS_DATA/knox2018
 
-    # file name
-    # source-ji2021_desc-kirst2020_space-allenccfv3_res-region_tabular.csv
+    # region mapping files
+    # source-knox2018_regionmapping.csv
 
-    # region mapping file
-    # source-ji2021_regionmapping.csv
 
-ji2021-todorov2020-allenccfv3-region
-------------------------------------
+----
 
-**Description**: Todorov 2020
+Allen Mouse Brain Atlas gene expression (lein2006amba)
+======================================================
 
-**Format**: tabular
+Allen Mouse Brain Atlas (Lein et al., 2006) — regional gene
+expression data aggregated across sagittal and coronal sections.
+
+For each section type (sagittal, coronal), three expression metrics
+are provided: energy, density, and intensity. Each file is a
+region-by-gene matrix where rows are Allen CCFv3 regions and columns
+are genes (see feature mapping file for gene names).
+
+This is a large dataset; files are compressed (.csv.gz).
+
+.. warning:: This is a very large dataset, and may take a long time to download.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Expression energy of sagittal slices
+     - tabular
+     - ``('lein2006amba', 'sagittalenergy', 'allenccfv3', 'region')``
+   * - Expression energy of coronal slices
+     - tabular
+     - ``('lein2006amba', 'coronalenergy', 'allenccfv3', 'region')``
+   * - Expression density of sagittal slices
+     - tabular
+     - ``('lein2006amba', 'sagittaldensity', 'allenccfv3', 'region')``
+   * - Expression density of coronal slices
+     - tabular
+     - ``('lein2006amba', 'coronaldensity', 'allenccfv3', 'region')``
+   * - Expression intensity of sagittal slices
+     - tabular
+     - ``('lein2006amba', 'sagittalintensity', 'allenccfv3', 'region')``
+   * - Expression intensity of coronal slices
+     - tabular
+     - ``('lein2006amba', 'coronalintensity', 'allenccfv3', 'region')``
 
 **How to use**
 
 .. code:: python
 
-    # get annotation
-    fetch_annotation(('ji2021', 'todorov2020', 'allenccfv3', 'region'))
+    # fetch a specific annotation
+    fetch_annotation(('lein2006amba', 'sagittalenergy', 'allenccfv3', 'region'))
 
     # file location
-    # $MOUSEMAPS_DATA/ji2021
+    # $MOUSEMAPS_DATA/lein2006amba
 
-    # file name
-    # source-ji2021_desc-todorov2020_space-allenccfv3_res-region_tabular.csv
+    # region mapping files
+    # source-lein2006amba_regionmapping.csv
 
-    # region mapping file
-    # source-ji2021_regionmapping.csv
+    # feature mapping files
+    # source-lein2006amba_genemapping.csv
 
-**References**
+
+----
+
+Cell-type-specific functional connectivity (mandino2025)
+========================================================
+
+Cell-type-specific functional connectivity matrices from
+Mandino et al. (2025), combining calcium imaging and fMRI.
+
+Files are organized by modality (calcium imaging: ``cal`` prefix,
+fMRI: ``fmri`` prefix), cell type (PV, VIP, SLC, SOM, glia),
+and whether global signal regression was applied
+(``gsr`` = with GSR, ``nogsr`` = without GSR).
+
+For example, ``calpvallgsr`` is the calcium imaging PV cell matrix
+with GSR. Each file is a region-by-region connectivity matrix.
+Region mappings differ between modalities.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Calcium imaging PV with GSR
+     - matrix
+     - ``('mandino2025', 'calpvallgsr', 'allenccfv3', 'region')``
+   * - Calcium imaging PV without GSR
+     - matrix
+     - ``('mandino2025', 'calpvallnogsr', 'allenccfv3', 'region')``
+   * - Calcium imaging VIP with GSR
+     - matrix
+     - ``('mandino2025', 'calvipallgsr', 'allenccfv3', 'region')``
+   * - Calcium imaging VIP without GSR
+     - matrix
+     - ``('mandino2025', 'calvipallnogsr', 'allenccfv3', 'region')``
+   * - Calcium imaging SLC with GSR
+     - matrix
+     - ``('mandino2025', 'calslcallgsr', 'allenccfv3', 'region')``
+   * - Calcium imaging SLC without GSR
+     - matrix
+     - ``('mandino2025', 'calslcallnogsr', 'allenccfv3', 'region')``
+   * - Calcium imaging SOM with GSR
+     - matrix
+     - ``('mandino2025', 'calsomallgsr', 'allenccfv3', 'region')``
+   * - Calcium imaging SOM without GSR
+     - matrix
+     - ``('mandino2025', 'calsomallnogsr', 'allenccfv3', 'region')``
+   * - Calcium imaging glia with GSR
+     - matrix
+     - ``('mandino2025', 'calgliaallgsr', 'allenccfv3', 'region')``
+   * - Calcium imaging glia without GSR
+     - matrix
+     - ``('mandino2025', 'calgliaallnogsr', 'allenccfv3', 'region')``
+   * - fMRI PV with GSR
+     - matrix
+     - ``('mandino2025', 'fmripvallgsr', 'allenccfv3', 'region')``
+   * - fMRI PV without GSR
+     - matrix
+     - ``('mandino2025', 'fmripvallnogsr', 'allenccfv3', 'region')``
+   * - fMRI VIP with GSR
+     - matrix
+     - ``('mandino2025', 'fmrivipallgsr', 'allenccfv3', 'region')``
+   * - fMRI VIP without GSR
+     - matrix
+     - ``('mandino2025', 'fmrivipallnogsr', 'allenccfv3', 'region')``
+   * - fMRI SLC with GSR
+     - matrix
+     - ``('mandino2025', 'fmrislcallgsr', 'allenccfv3', 'region')``
+   * - fMRI SLC without GSR
+     - matrix
+     - ``('mandino2025', 'fmrislcallnogsr', 'allenccfv3', 'region')``
+   * - fMRI SOM with GSR
+     - matrix
+     - ``('mandino2025', 'fmrisomallgsr', 'allenccfv3', 'region')``
+   * - fMRI SOM without GSR
+     - matrix
+     - ``('mandino2025', 'fmrisomallnogsr', 'allenccfv3', 'region')``
+   * - fMRI glia with GSR
+     - matrix
+     - ``('mandino2025', 'fmrigliaallgsr', 'allenccfv3', 'region')``
+   * - fMRI glia without GSR
+     - matrix
+     - ``('mandino2025', 'fmrigliaallnogsr', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
+    fetch_annotation(('mandino2025', 'calpvallgsr', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/mandino2025
+
+    # region mapping files
+    # source-mandino2025_cal_regionmapping.csv
+    # source-mandino2025_fmri_regionmapping.csv
+
+
+----
+
+Homogeneous and voxel-scale connectivity models (nathan2026)
+============================================================
+
+Connectivity matrices from Nathan et al. (2026) providing two
+complementary models of mouse brain connectivity.
+
+The homogeneous model (``hom``) is a linear connectivity model via
+constrained optimization and linear regression, similar to
+Oh et al. (2014).
+
+The voxel-scale model (``vox``) from Knox et al. (2018) performs
+Nadaraya-Watson regression to infer voxel-to-voxel connectivity,
+splitting the source space into 12 major brain divisions to prevent
+influence from adjacent divisions. The voxel-scale results are then
+regionalized into Allen CCFv3 regions.
+
+Files are further organized by:
+
+- Laterality: ``ipsi`` (ipsilateral) or ``contra`` (contralateral)
+- Quality: ``orig`` (original methods) or ``qc`` (carefully QC-ed
+  experiments providing a refined connectome)
+- Resolution: ``211`` (regions from Oh et al., 2014) or ``291``
+  (regions from Knox et al., 2018)
+
+Each resolution has its own region mapping file (``r211``, ``r291``).
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Homotopic ipsilateral QC at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'homipsiqc211', 'allenccfv3', 'region')``
+   * - Homotopic ipsilateral QC at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'homipsiqc291', 'allenccfv3', 'region')``
+   * - Homotopic ipsilateral original at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'homipsiorig211', 'allenccfv3', 'region')``
+   * - Homotopic ipsilateral original at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'homipsiorig291', 'allenccfv3', 'region')``
+   * - Homotopic contralateral QC at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'homcontraqc211', 'allenccfv3', 'region')``
+   * - Homotopic contralateral QC at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'homcontraqc291', 'allenccfv3', 'region')``
+   * - Homotopic contralateral original at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'homcontraorig211', 'allenccfv3', 'region')``
+   * - Homotopic contralateral original at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'homcontraorig291', 'allenccfv3', 'region')``
+   * - Voxelwise ipsilateral QC at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'voxipsiqc211', 'allenccfv3', 'region')``
+   * - Voxelwise ipsilateral QC at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'voxipsiqc291', 'allenccfv3', 'region')``
+   * - Voxelwise ipsilateral original at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'voxipsiorig211', 'allenccfv3', 'region')``
+   * - Voxelwise ipsilateral original at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'voxipsiorig291', 'allenccfv3', 'region')``
+   * - Voxelwise contralateral QC at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'voxcontraqc211', 'allenccfv3', 'region')``
+   * - Voxelwise contralateral QC at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'voxcontraqc291', 'allenccfv3', 'region')``
+   * - Voxelwise contralateral original at 211 region resolution
+     - matrix
+     - ``('nathan2026', 'voxcontraorig211', 'allenccfv3', 'region')``
+   * - Voxelwise contralateral original at 291 region resolution
+     - matrix
+     - ``('nathan2026', 'voxcontraorig291', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
+    fetch_annotation(('nathan2026', 'homipsiqc211', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/nathan2026
+
+    # region mapping files
+    # source-nathan2026_r211_regionmapping.csv
+    # source-nathan2026_r291_regionmapping.csv
+
+
+----
+
+Mesoscale structural connectome (oh2014)
+========================================
+
+A mesoscale connectome of the mouse brain (Oh et al., 2014).
+
+Provides weighted connectivity strength, p-values, and projection
+distances for both ipsi- and contralateral projections across
+Allen CCFv3 regions.
+
+Original source: Supplementary Table 3.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Weighted ipsilateral strength index
+     - matrix
+     - ``('oh2014', 'wipsi', 'allenccfv3', 'region')``
+   * - P values for wipsi
+     - matrix
+     - ``('oh2014', 'pvalipsi', 'allenccfv3', 'region')``
+   * - Weighted contralateral strength index
+     - matrix
+     - ``('oh2014', 'wcontra', 'allenccfv3', 'region')``
+   * - P values for wcontra
+     - matrix
+     - ``('oh2014', 'pvalcontra', 'allenccfv3', 'region')``
+   * - Distance (mm) for ipsilateral projections
+     - matrix
+     - ``('oh2014', 'distipsi', 'allenccfv3', 'region')``
+   * - Distance (mm) for contralateral projections
+     - matrix
+     - ``('oh2014', 'distcontra', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
+    fetch_annotation(('oh2014', 'wipsi', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/oh2014
+
+    # region mapping files
+    # source-oh2014_regionmapping.csv
+
+
+----
+
+ABC Atlas MERFISH cell types and gene expression (yao2023abca)
+==============================================================
+
+Mouse whole-brain transcriptomic cell type atlas from the
+Allen Brain Cell Atlas (Yao et al., 2023), MERFISH dataset
+(C57BL6J-638850).
+
+Gene expression files (``*mean``) are region-by-gene matrices
+averaged at three hierarchical levels: division (``divi``),
+structure (``stru``), and substructure (``subs``).
+``imp`` prefix indicates imputed expression values.
+
+Cell type files (``*ct*``) are region-by-cell-type matrices
+at four classification levels: class, subclass, supertype, cluster,
+each at the three hierarchical region levels.
+
+Each hierarchical level uses its own region mapping file.
+Separate feature mapping files are provided for measured and
+imputed gene sets.
+
+This is a large dataset; files may take a long time to download.
+
+.. warning:: This is a very large dataset, and may take a long time to download.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Average regional gene expressions at the division level
+     - tabular
+     - ``('yao2023abca', 'divimean', 'allenccfv3', 'region')``
+   * - Average regional gene expressions at the structure level
+     - tabular
+     - ``('yao2023abca', 'strumean', 'allenccfv3', 'region')``
+   * - Average regional gene expressions at the substructure level
+     - tabular
+     - ``('yao2023abca', 'subsmean', 'allenccfv3', 'region')``
+   * - Average imputed regional gene expressions at the division level
+     - tabular
+     - ``('yao2023abca', 'impdivimean', 'allenccfv3', 'region')``
+   * - Average imputed regional gene expressions at the structure level
+     - tabular
+     - ``('yao2023abca', 'impstrumean', 'allenccfv3', 'region')``
+   * - Average imputed regional gene expressions at the substructure level
+     - tabular
+     - ``('yao2023abca', 'impsubsmean', 'allenccfv3', 'region')``
+   * - Cell type (class) at the division level
+     - tabular
+     - ``('yao2023abca', 'divictclass', 'allenccfv3', 'region')``
+   * - Cell type (class) at the structure level
+     - tabular
+     - ``('yao2023abca', 'structclass', 'allenccfv3', 'region')``
+   * - Cell type (class) at the substructure level
+     - tabular
+     - ``('yao2023abca', 'subsctclass', 'allenccfv3', 'region')``
+   * - Cell type (subclass) at the division level
+     - tabular
+     - ``('yao2023abca', 'divictsubclass', 'allenccfv3', 'region')``
+   * - Cell type (subclass) at the structure level
+     - tabular
+     - ``('yao2023abca', 'structsubclass', 'allenccfv3', 'region')``
+   * - Cell type (subclass) at the substructure level
+     - tabular
+     - ``('yao2023abca', 'subsctsubclass', 'allenccfv3', 'region')``
+   * - Cell type (supertype) at the division level
+     - tabular
+     - ``('yao2023abca', 'divictsupertype', 'allenccfv3', 'region')``
+   * - Cell type (supertype) at the structure level
+     - tabular
+     - ``('yao2023abca', 'structsupertype', 'allenccfv3', 'region')``
+   * - Cell type (supertype) at the substructure level
+     - tabular
+     - ``('yao2023abca', 'subsctsupertype', 'allenccfv3', 'region')``
+   * - Cell type (cluster) at the division level
+     - tabular
+     - ``('yao2023abca', 'divictcluster', 'allenccfv3', 'region')``
+   * - Cell type (cluster) at the structure level
+     - tabular
+     - ``('yao2023abca', 'structcluster', 'allenccfv3', 'region')``
+   * - Cell type (cluster) at the substructure level
+     - tabular
+     - ``('yao2023abca', 'subsctcluster', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
+    fetch_annotation(('yao2023abca', 'divimean', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/yao2023abca
+
+    # region mapping files
+    # source-yao2023abca_division_regionmapping.csv
+    # source-yao2023abca_structure_regionmapping.csv
+    # source-yao2023abca_substructure_regionmapping.csv
+
+    # feature mapping files
+    # source-yao2023abca_merfish_genemapping.csv
+    # source-yao2023abca_imputed_genemapping.csv
+
+
+----
+
+ABC Atlas Zhuang-ABCA gene expression (zhang2023abca)
+=====================================================
+
+A molecularly defined and spatially resolved cell atlas of the
+whole mouse brain (Zhang et al., 2023, Zhuang-ABCA MERFISH).
+
+Gene expression files are region-by-gene matrices averaged at
+three hierarchical levels: division (``divi``), structure
+(``stru``), and substructure (``subs``). Each level uses its own
+region mapping file.
+
+This is a large dataset; files may take a long time to download.
+
+.. warning:: This is a very large dataset, and may take a long time to download.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Average regional gene expressions at the division level
+     - tabular
+     - ``('zhang2023abca', 'divimean', 'allenccfv3', 'region')``
+   * - Average regional gene expressions at the structure level
+     - tabular
+     - ``('zhang2023abca', 'strumean', 'allenccfv3', 'region')``
+   * - Average regional gene expressions at the substructure level
+     - tabular
+     - ``('zhang2023abca', 'subsmean', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
+    fetch_annotation(('zhang2023abca', 'divimean', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/zhang2023abca
+
+    # region mapping files
+    # source-zhang2023abca_division_regionmapping.csv
+    # source-zhang2023abca_structure_regionmapping.csv
+    # source-zhang2023abca_substructure_regionmapping.csv
+
+    # feature mapping files
+    # source-zhang2023abca_merfish_genemapping.csv
+
+
+----
+
+Brain synaptome architecture (zhu2018)
+======================================
+
+Architecture of the Mouse Brain Synaptome (Zhu et al., 2018).
+
+Provides synaptic type density measurements across Allen CCFv3
+brain regions, characterizing the molecular and cellular
+composition of synapses throughout the mouse brain.
+
+**Available files**
+
+.. list-table::
+   :header-rows: 1
+
+   * - Description
+     - Format
+     - Key
+   * - Synaptic type density
+     - tabular
+     - ``('zhu2018', 'typedensity', 'allenccfv3', 'region')``
+
+**How to use**
+
+.. code:: python
+
+    # fetch a specific annotation
+    fetch_annotation(('zhu2018', 'typedensity', 'allenccfv3', 'region'))
+
+    # file location
+    # $MOUSEMAPS_DATA/zhu2018
+
+    # region mapping files
+    # source-zhu2018_regionmapping.csv
+

--- a/neuromaps_mouse/datasets/__init__.py
+++ b/neuromaps_mouse/datasets/__init__.py
@@ -1,7 +1,7 @@
 """Functions to fetch and load datasets."""
 
-from .annotations import available_annotations, fetch_annotation
-from .atlases import fetch_allenccfv3, fetch_all_atlases
+from .annotations import available_annotations, fetch_annotation, get_annotation_dir
+from .atlases import fetch_allenccfv3, fetch_all_atlases, get_atlas_dir
 from .utils import get_data_dir
 
 __all__ = [
@@ -10,4 +10,6 @@ __all__ = [
     "fetch_allenccfv3",
     "fetch_all_atlases",
     "get_data_dir",
+    "get_atlas_dir",
+    "get_annotation_dir"
 ]

--- a/neuromaps_mouse/datasets/annotations.py
+++ b/neuromaps_mouse/datasets/annotations.py
@@ -135,16 +135,16 @@ def fetch_annotation(annotations, data_dir=None, return_single=False, verbose=1)
         Path(s) to the downloaded annotation file(s). Returned as single
         string if return_single=True and one annotation was requested.
 
+    See Also
+    --------
+    neuromaps_mouse.datasets.available_annotations : List available annotations.
+    neuromaps_mouse.datasets.get_annotation_dir : Get the annotations directory path.
+
     Notes
     -----
     This function automatically downloads related metadata files (such as
     regionmapping files) for each annotation source. Files are cached locally
     to avoid re-downloading on subsequent calls.
-
-    See Also
-    --------
-    neuromaps_mouse.datasets.available_annotations : List available annotations.
-    neuromaps_mouse.datasets.get_annotation_dir : Get the annotations directory path.
 
     Examples
     --------
@@ -176,7 +176,7 @@ def fetch_annotation(annotations, data_dir=None, return_single=False, verbose=1)
 
     if verbose:
         print(f"Downloading regionmapping files for {source_list}")
-    targ_annot_meta_fname_list = _fetch_annotation_meta_files(
+    _fetch_annotation_meta_files(
         list(set([annot["source"] for annot in annotations_full])),
         which="regionmapping",
         data_dir=data_dir,

--- a/neuromaps_mouse/datasets/atlases.py
+++ b/neuromaps_mouse/datasets/atlases.py
@@ -8,11 +8,43 @@ from neuromaps_mouse.datasets.utils import (
 
 
 def get_atlas_dir(data_dir=None):
+    """Return path to the atlas data directory.
+
+    Parameters
+    ----------
+    data_dir : str or Path, optional
+        Base data directory. If None, uses the default. Default is None.
+
+    Returns
+    -------
+    Path
+        Path to the atlases subdirectory.
+    """
     data_dir = get_data_dir(data_dir=data_dir)
     return data_dir / "atlases"
 
 
 def fetch_allenccfv3(which=None, return_single=True, data_dir=None, verbose=1):
+    """Fetch Allen CCFv3 atlas files.
+
+    Parameters
+    ----------
+    which : str or list of str, optional
+        Which atlas file(s) to fetch. Use 'all' or None to fetch all.
+        Default is None.
+    return_single : bool, optional
+        If True and only one file is fetched, return a single path instead
+        of a list. Default is True.
+    data_dir : str or Path, optional
+        Base data directory. If None, uses the default. Default is None.
+    verbose : int, optional
+        Verbosity level. Default is 1.
+
+    Returns
+    -------
+    Path or list of Path
+        Path(s) to the fetched atlas file(s).
+    """
     data_dir = get_data_dir(data_dir=data_dir)
     atlas = MOUSEMAPS_ATLASES["allen-ccfv3"]
 
@@ -43,4 +75,5 @@ def fetch_allenccfv3(which=None, return_single=True, data_dir=None, verbose=1):
 
 
 def fetch_all_atlases():
+    """Fetch all available atlases."""
     pass

--- a/neuromaps_mouse/datasets/data/annotations-meta.json
+++ b/neuromaps_mouse/datasets/data/annotations-meta.json
@@ -1,13 +1,20 @@
 {
   "annotations-meta": [
     {
-      "source": "zhu2018",
-      "name": "synaptome",
-      "description": "Architecture of the Mouse Brain Synaptome",
+      "source": "aboharb2025",
+      "name": "Psychedelic drug activation maps",
+      "description": "Regional brain activation maps following administration of various\npsychedelic compounds and controls, measured via whole-brain imaging.\n\nEach file contains activation values for a single treatment condition:\npsychedelics (5-MeO, 6-F-DET, Ketamine, MDMA, Psilocybin),\nantidepressant controls (ASSRI, CSSRI), and saline control.",
       "file_desc": {
-        "typedensity": "Synaptic type density"
+        "5meo": "5-MeO",
+        "6fdet": "6-F-DET",
+        "assri": "ASSRI",
+        "cssri": "CSSRI",
+        "ket": "Ketamine",
+        "mdma": "MDMA",
+        "psi": "Psilocybin",
+        "sal": "Saline"
       },
-      "comments": "Original source: ",
+      "comments": "",
       "refs": [
         {
           "citation": "",
@@ -16,8 +23,50 @@
       ],
       "files": [
         [
-          "zhu2018",
-          "typedensity",
+          "aboharb2025",
+          "5meo",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "6fdet",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "assri",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "cssri",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "ket",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "mdma",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "psi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "aboharb2025",
+          "sal",
           "allenccfv3",
           "region"
         ]
@@ -25,82 +74,11 @@
       "aux_files": {
         "regionmapping": {
           "format": "regionmapping",
-          "fname": "source-zhu2018_regionmapping.csv",
-          "rel_path": "zhu2018",
-          "checksum": "c04520b402e11e704222195ca58217ed",
+          "fname": "source-aboharb2025_regionmapping.csv",
+          "rel_path": "aboharb2025",
+          "checksum": "428fd5724c5043a77e79fb187a63d01d",
           "url": {
-            "osf": "8z4yf",
-            "original": ""
-          },
-          "comments": ""
-        }
-      }
-    },
-    {
-      "source": "oh2014",
-      "name": "structural connectome",
-      "description": "A mesoscale connectome of the mouse brain",
-      "file_desc": {
-        "wipsi": "Weighted ipsilateral strength index",
-        "pvalipsi": "P values for wipsi",
-        "wcontra": "Weighted contralateral strength index",
-        "pvalcontra": "P values for wcontra",
-        "distipsi": "Distance (mm) for ipsilateral projections",
-        "distcontra": "Distance (mm) for contralateral projections"
-      },
-      "comments": "Original source: Supplementary Table 3",
-      "refs": [
-        {
-          "citation": "",
-          "bibkey": ""
-        }
-      ],
-      "files": [
-        [
-          "oh2014",
-          "wipsi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "oh2014",
-          "pvalipsi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "oh2014",
-          "wcontra",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "oh2014",
-          "pvalcontra",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "oh2014",
-          "distipsi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "oh2014",
-          "distcontra",
-          "allenccfv3",
-          "region"
-        ]
-      ],
-      "aux_files": {
-        "regionmapping": {
-          "format": "regionmapping",
-          "fname": "source-oh2014_regionmapping.csv",
-          "rel_path": "oh2014",
-          "checksum": "38e150dbe5dffcf79ecc831279b63c88",
-          "url": {
-            "osf": "hc4da",
+            "osf": "4u8kx",
             "original": ""
           },
           "comments": ""
@@ -109,8 +87,8 @@
     },
     {
       "source": "ero2018",
-      "name": "cell type density",
-      "description": "A Cell Atlas for the Mouse Brain",
+      "name": "Cell type density atlas",
+      "description": "A Cell Atlas for the Mouse Brain (Ero et al., 2018).\n\nProvides density estimates of major cell types across\nAllen CCFv3 brain regions, derived from single-cell RNA sequencing\nand in situ hybridization data.",
       "file_desc": {
         "celldensity": "Density of cell types"
       },
@@ -144,9 +122,187 @@
       }
     },
     {
+      "source": "ibl2025",
+      "name": "IBL behavioral and electrophysiology maps",
+      "description": "Regional brain maps from the International Brain Laboratory (IBL)\nreproducible brain-wide mapping pipeline.\n\nIncludes behavioral task performance metrics and electrophysiology\nsummary statistics mapped to Allen CCFv3 regions.",
+      "file_desc": {
+        "behtask": "Behavioral task",
+        "ephys": "Electrophysiology"
+      },
+      "comments": "",
+      "refs": [
+        {
+          "citation": "",
+          "bibkey": ""
+        }
+      ],
+      "files": [
+        [
+          "ibl2025",
+          "behtask",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "ibl2025",
+          "ephys",
+          "allenccfv3",
+          "region"
+        ]
+      ],
+      "aux_files": {
+        "regionmapping": {
+          "format": "regionmapping",
+          "fname": "source-ibl2025_regionmapping.csv",
+          "rel_path": "ibl2025",
+          "checksum": "41ae7b8242a454ad1cce101ad2b23b1d",
+          "url": {
+            "osf": "gxedp",
+            "original": ""
+          },
+          "comments": ""
+        }
+      }
+    },
+    {
+      "source": "ji2021",
+      "name": "Brain microvasculature",
+      "description": "Brain microvasculature has a common topology with local differences\nin geometry that match metabolic load (Ji et al., 2021).\n\nWhole mouse brain microvasculature imaged, reconstructed,\nand analyzed at sub-micrometer resolution. Includes data from\nJi et al. (2021), Kirst et al. (2020), and Todorov et al. (2020).\n\nEach file contains region-level tabular data characterizing\nmicrovascular network properties across Allen CCFv3 regions.",
+      "file_desc": {
+        "ji2021": "Ji 2021",
+        "kirst2020": "Kirst 2020",
+        "todorov2020": "Todorov 2020"
+      },
+      "comments": "",
+      "refs": [
+        {
+          "citation": "",
+          "bibkey": ""
+        }
+      ],
+      "files": [
+        [
+          "ji2021",
+          "ji2021",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "ji2021",
+          "kirst2020",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "ji2021",
+          "todorov2020",
+          "allenccfv3",
+          "region"
+        ]
+      ],
+      "aux_files": {
+        "regionmapping": {
+          "format": "regionmapping",
+          "fname": "source-ji2021_regionmapping.csv",
+          "rel_path": "ji2021",
+          "checksum": "41ee7295dd3e82c504b163c6fd2674fd",
+          "url": {
+            "osf": "mx4rv",
+            "original": ""
+          },
+          "comments": ""
+        }
+      }
+    },
+    {
+      "source": "knox2018",
+      "name": "High-resolution connectome model",
+      "description": "A high-resolution data-driven model of the mouse connectome\n(Knox et al., 2018).\n\nProvides region-by-region connectivity matrices at the Allen CCFv3\nparcellation. Each matrix is asymmetric: rows are source regions and\ncolumns are target regions. Available for both ipsi- and contralateral\nprojections, in connection density and connection strength variants,\neach with normalized versions.",
+      "file_desc": {
+        "conndencontra": "Connection density (contralateral)",
+        "conndenipsi": "Connection density (ipsilateral)",
+        "connstrcontra": "Connection strength (contralateral)",
+        "connstripsi": "Connection strength (ipsilateral)",
+        "normconndencontra": "Normalized connection density (contralateral)",
+        "normconndenipsi": "Normalized connection density (ipsilateral)",
+        "normconnstrcontra": "Normalized connection strength (contralateral)",
+        "normconnstripsi": "Normalized connection strength (ipsilateral)"
+      },
+      "comments": "Note that the matrix is not symmetric. Rows are source regions and columns are target regions. For the contralaeral matrices, several missing columns (targets) are filled with NaN (['EW', 'OV', 'RM', 'RO', 'RPA'] for all 4 variants, and an additional 'VISa' for connection density (conndencontra)).",
+      "refs": [
+        {
+          "citation": "",
+          "bibkey": ""
+        }
+      ],
+      "files": [
+        [
+          "knox2018",
+          "conndencontra",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "conndenipsi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "connstrcontra",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "connstripsi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "normconndencontra",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "normconndenipsi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "normconnstrcontra",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "knox2018",
+          "normconnstripsi",
+          "allenccfv3",
+          "region"
+        ]
+      ],
+      "aux_files": {
+        "regionmapping": {
+          "format": "regionmapping",
+          "fname": "source-knox2018_regionmapping.csv",
+          "rel_path": "knox2018",
+          "checksum": "30506af3217b6700d1cdf906311ea7b0",
+          "url": {
+            "osf": "ad39w",
+            "original": ""
+          },
+          "comments": ""
+        }
+      }
+    },
+    {
       "source": "lein2006amba",
-      "name": "Allen Mouse Brain Atlas",
-      "description": "Allen Mouse Brain Atlas",
+      "name": "Allen Mouse Brain Atlas gene expression",
+      "description": "Allen Mouse Brain Atlas (Lein et al., 2006) \u2014 regional gene\nexpression data aggregated across sagittal and coronal sections.\n\nFor each section type (sagittal, coronal), three expression metrics\nare provided: energy, density, and intensity. Each file is a\nregion-by-gene matrix where rows are Allen CCFv3 regions and columns\nare genes (see feature mapping file for gene names).\n\nThis is a large dataset; files are compressed (.csv.gz).",
       "file_desc": {
         "sagittalenergy": "Expression energy of sagittal slices",
         "coronalenergy": "Expression energy of coronal slices",
@@ -227,9 +383,416 @@
       }
     },
     {
+      "source": "mandino2025",
+      "name": "Cell-type-specific functional connectivity",
+      "description": "Cell-type-specific functional connectivity matrices from\nMandino et al. (2025), combining calcium imaging and fMRI.\n\nFiles are organized by modality (calcium imaging: ``cal`` prefix,\nfMRI: ``fmri`` prefix), cell type (PV, VIP, SLC, SOM, glia),\nand whether global signal regression was applied\n(``gsr`` = with GSR, ``nogsr`` = without GSR).\n\nFor example, ``calpvallgsr`` is the calcium imaging PV cell matrix\nwith GSR. Each file is a region-by-region connectivity matrix.\nRegion mappings differ between modalities.",
+      "file_desc": {
+        "calpvallgsr": "Calcium imaging PV with GSR",
+        "calpvallnogsr": "Calcium imaging PV without GSR",
+        "calvipallgsr": "Calcium imaging VIP with GSR",
+        "calvipallnogsr": "Calcium imaging VIP without GSR",
+        "calslcallgsr": "Calcium imaging SLC with GSR",
+        "calslcallnogsr": "Calcium imaging SLC without GSR",
+        "calsomallgsr": "Calcium imaging SOM with GSR",
+        "calsomallnogsr": "Calcium imaging SOM without GSR",
+        "calgliaallgsr": "Calcium imaging glia with GSR",
+        "calgliaallnogsr": "Calcium imaging glia without GSR",
+        "fmripvallgsr": "fMRI PV with GSR",
+        "fmripvallnogsr": "fMRI PV without GSR",
+        "fmrivipallgsr": "fMRI VIP with GSR",
+        "fmrivipallnogsr": "fMRI VIP without GSR",
+        "fmrislcallgsr": "fMRI SLC with GSR",
+        "fmrislcallnogsr": "fMRI SLC without GSR",
+        "fmrisomallgsr": "fMRI SOM with GSR",
+        "fmrisomallnogsr": "fMRI SOM without GSR",
+        "fmrigliaallgsr": "fMRI glia with GSR",
+        "fmrigliaallnogsr": "fMRI glia without GSR"
+      },
+      "comments": "",
+      "refs": [
+        {
+          "citation": "",
+          "bibkey": ""
+        }
+      ],
+      "files": [
+        [
+          "mandino2025",
+          "calpvallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calpvallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calvipallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calvipallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calslcallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calslcallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calsomallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calsomallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calgliaallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "calgliaallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmripvallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmripvallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrivipallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrivipallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrislcallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrislcallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrisomallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrisomallnogsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrigliaallgsr",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "mandino2025",
+          "fmrigliaallnogsr",
+          "allenccfv3",
+          "region"
+        ]
+      ],
+      "aux_files": {
+        "regionmapping": [
+          {
+            "format": "regionmapping",
+            "fname": "source-mandino2025_cal_regionmapping.csv",
+            "rel_path": "mandino2025",
+            "checksum": "e76f60933a2f4ae090c041ed5acedb25",
+            "url": {
+              "osf": "6x3w4",
+              "original": ""
+            },
+            "comments": ""
+          },
+          {
+            "format": "regionmapping",
+            "fname": "source-mandino2025_fmri_regionmapping.csv",
+            "rel_path": "mandino2025",
+            "checksum": "e7cde3d3c365c112930a818f7ef6a488",
+            "url": {
+              "osf": "9cjyw",
+              "original": ""
+            },
+            "comments": ""
+          }
+        ]
+      }
+    },
+    {
+      "source": "nathan2026",
+      "name": "Homogeneous and voxel-scale connectivity models",
+      "description": "Connectivity matrices from Nathan et al. (2026) providing two\ncomplementary models of mouse brain connectivity.\n\nThe homogeneous model (``hom``) is a linear connectivity model via\nconstrained optimization and linear regression, similar to\nOh et al. (2014).\n\nThe voxel-scale model (``vox``) from Knox et al. (2018) performs\nNadaraya-Watson regression to infer voxel-to-voxel connectivity,\nsplitting the source space into 12 major brain divisions to prevent\ninfluence from adjacent divisions. The voxel-scale results are then\nregionalized into Allen CCFv3 regions.\n\nFiles are further organized by:\n\n- Laterality: ``ipsi`` (ipsilateral) or ``contra`` (contralateral)\n- Quality: ``orig`` (original methods) or ``qc`` (carefully QC-ed\n  experiments providing a refined connectome)\n- Resolution: ``211`` (regions from Oh et al., 2014) or ``291``\n  (regions from Knox et al., 2018)\n\nEach resolution has its own region mapping file (``r211``, ``r291``).",
+      "file_desc": {
+        "homipsiqc211": "Homotopic ipsilateral QC at 211 region resolution",
+        "homipsiqc291": "Homotopic ipsilateral QC at 291 region resolution",
+        "homipsiorig211": "Homotopic ipsilateral original at 211 region resolution",
+        "homipsiorig291": "Homotopic ipsilateral original at 291 region resolution",
+        "homcontraqc211": "Homotopic contralateral QC at 211 region resolution",
+        "homcontraqc291": "Homotopic contralateral QC at 291 region resolution",
+        "homcontraorig211": "Homotopic contralateral original at 211 region resolution",
+        "homcontraorig291": "Homotopic contralateral original at 291 region resolution",
+        "voxipsiqc211": "Voxelwise ipsilateral QC at 211 region resolution",
+        "voxipsiqc291": "Voxelwise ipsilateral QC at 291 region resolution",
+        "voxipsiorig211": "Voxelwise ipsilateral original at 211 region resolution",
+        "voxipsiorig291": "Voxelwise ipsilateral original at 291 region resolution",
+        "voxcontraqc211": "Voxelwise contralateral QC at 211 region resolution",
+        "voxcontraqc291": "Voxelwise contralateral QC at 291 region resolution",
+        "voxcontraorig211": "Voxelwise contralateral original at 211 region resolution",
+        "voxcontraorig291": "Voxelwise contralateral original at 291 region resolution"
+      },
+      "comments": "",
+      "refs": [
+        {
+          "citation": "",
+          "bibkey": ""
+        }
+      ],
+      "files": [
+        [
+          "nathan2026",
+          "homipsiqc211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homipsiqc291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homipsiorig211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homipsiorig291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homcontraqc211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homcontraqc291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homcontraorig211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "homcontraorig291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxipsiqc211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxipsiqc291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxipsiorig211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxipsiorig291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxcontraqc211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxcontraqc291",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxcontraorig211",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "nathan2026",
+          "voxcontraorig291",
+          "allenccfv3",
+          "region"
+        ]
+      ],
+      "aux_files": {
+        "regionmapping": [
+          {
+            "format": "regionmapping",
+            "fname": "source-nathan2026_r211_regionmapping.csv",
+            "rel_path": "nathan2026",
+            "checksum": "ed4b5455b4d8fb299af386783f35d95c",
+            "url": {
+              "osf": "hsv4z",
+              "original": ""
+            },
+            "comments": ""
+          },
+          {
+            "format": "regionmapping",
+            "fname": "source-nathan2026_r291_regionmapping.csv",
+            "rel_path": "nathan2026",
+            "checksum": "59a88dbe86a5c581e2198e50689e4a7c",
+            "url": {
+              "osf": "wzv7n",
+              "original": ""
+            },
+            "comments": ""
+          }
+        ]
+      }
+    },
+    {
+      "source": "oh2014",
+      "name": "Mesoscale structural connectome",
+      "description": "A mesoscale connectome of the mouse brain (Oh et al., 2014).\n\nProvides weighted connectivity strength, p-values, and projection\ndistances for both ipsi- and contralateral projections across\nAllen CCFv3 regions.\n\nOriginal source: Supplementary Table 3.",
+      "file_desc": {
+        "wipsi": "Weighted ipsilateral strength index",
+        "pvalipsi": "P values for wipsi",
+        "wcontra": "Weighted contralateral strength index",
+        "pvalcontra": "P values for wcontra",
+        "distipsi": "Distance (mm) for ipsilateral projections",
+        "distcontra": "Distance (mm) for contralateral projections"
+      },
+      "comments": "Original source: Supplementary Table 3",
+      "refs": [
+        {
+          "citation": "",
+          "bibkey": ""
+        }
+      ],
+      "files": [
+        [
+          "oh2014",
+          "wipsi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "oh2014",
+          "pvalipsi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "oh2014",
+          "wcontra",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "oh2014",
+          "pvalcontra",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "oh2014",
+          "distipsi",
+          "allenccfv3",
+          "region"
+        ],
+        [
+          "oh2014",
+          "distcontra",
+          "allenccfv3",
+          "region"
+        ]
+      ],
+      "aux_files": {
+        "regionmapping": {
+          "format": "regionmapping",
+          "fname": "source-oh2014_regionmapping.csv",
+          "rel_path": "oh2014",
+          "checksum": "38e150dbe5dffcf79ecc831279b63c88",
+          "url": {
+            "osf": "hc4da",
+            "original": ""
+          },
+          "comments": ""
+        }
+      }
+    },
+    {
       "source": "yao2023abca",
-      "name": "ABC Atlas (MERFISH-C57BL6J-638850)",
-      "description": "Mouse whole-brain transcriptomic cell type atlas (Hongkui Zeng)",
+      "name": "ABC Atlas MERFISH cell types and gene expression",
+      "description": "Mouse whole-brain transcriptomic cell type atlas from the\nAllen Brain Cell Atlas (Yao et al., 2023), MERFISH dataset\n(C57BL6J-638850).\n\nGene expression files (``*mean``) are region-by-gene matrices\naveraged at three hierarchical levels: division (``divi``),\nstructure (``stru``), and substructure (``subs``).\n``imp`` prefix indicates imputed expression values.\n\nCell type files (``*ct*``) are region-by-cell-type matrices\nat four classification levels: class, subclass, supertype, cluster,\neach at the three hierarchical region levels.\n\nEach hierarchical level uses its own region mapping file.\nSeparate feature mapping files are provided for measured and\nimputed gene sets.\n\nThis is a large dataset; files may take a long time to download.",
       "file_desc": {
         "divimean": "Average regional gene expressions at the division level",
         "strumean": "Average regional gene expressions at the structure level",
@@ -432,8 +995,8 @@
     },
     {
       "source": "zhang2023abca",
-      "name": "ABC Atlas (Zhuang-ABCA)",
-      "description": "A molecularly defined and spatially resolved cell atlas of the whole mouse brain (Xiaowei Zhuang)",
+      "name": "ABC Atlas Zhuang-ABCA gene expression",
+      "description": "A molecularly defined and spatially resolved cell atlas of the\nwhole mouse brain (Zhang et al., 2023, Zhuang-ABCA MERFISH).\n\nGene expression files are region-by-gene matrices averaged at\nthree hierarchical levels: division (``divi``), structure\n(``stru``), and substructure (``subs``). Each level uses its own\nregion mapping file.\n\nThis is a large dataset; files may take a long time to download.",
       "file_desc": {
         "divimean": "Average regional gene expressions at the division level",
         "strumean": "Average regional gene expressions at the structure level",
@@ -517,20 +1080,13 @@
       }
     },
     {
-      "source": "knox2018",
-      "name": "hi-res connectome",
-      "description": " High-resolution data-driven model of the mouse connectome",
+      "source": "zhu2018",
+      "name": "Brain synaptome architecture",
+      "description": "Architecture of the Mouse Brain Synaptome (Zhu et al., 2018).\n\nProvides synaptic type density measurements across Allen CCFv3\nbrain regions, characterizing the molecular and cellular\ncomposition of synapses throughout the mouse brain.",
       "file_desc": {
-        "conndencontra": "Connection density (contralateral)",
-        "conndenipsi": "Connection density (ipsilateral)",
-        "connstrcontra": "Connection strength (contralateral)",
-        "connstripsi": "Connection strength (ipsilateral)",
-        "normconndencontra": "Normalized connection density (contralateral)",
-        "normconndenipsi": "Normalized connection density (ipsilateral)",
-        "normconnstrcontra": "Normalized connection strength (contralateral)",
-        "normconnstripsi": "Normalized connection strength (ipsilateral)"
+        "typedensity": "Synaptic type density"
       },
-      "comments": "Note that the matrix is not symmetric. Rows are source regions and columns are target regions. For the contralaeral matrices, several missing columns (targets) are filled with NaN (['EW', 'OV', 'RM', 'RO', 'RPA'] for all 4 variants, and an additional 'VISa' for connection density (conndencontra)).",
+      "comments": "Original source: ",
       "refs": [
         {
           "citation": "",
@@ -539,50 +1095,8 @@
       ],
       "files": [
         [
-          "knox2018",
-          "conndencontra",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "conndenipsi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "connstrcontra",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "connstripsi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "normconndencontra",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "normconndenipsi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "normconnstrcontra",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "knox2018",
-          "normconnstripsi",
+          "zhu2018",
+          "typedensity",
           "allenccfv3",
           "region"
         ]
@@ -590,189 +1104,11 @@
       "aux_files": {
         "regionmapping": {
           "format": "regionmapping",
-          "fname": "source-knox2018_regionmapping.csv",
-          "rel_path": "knox2018",
-          "checksum": "30506af3217b6700d1cdf906311ea7b0",
+          "fname": "source-zhu2018_regionmapping.csv",
+          "rel_path": "zhu2018",
+          "checksum": "c04520b402e11e704222195ca58217ed",
           "url": {
-            "osf": "ad39w",
-            "original": ""
-          },
-          "comments": ""
-        }
-      }
-    },
-    {
-      "source": "aboharb2025",
-      "name": "aboharb2025",
-      "description": "",
-      "file_desc": {
-        "5meo": "5-MeO",
-        "6fdet": "6-F-DET",
-        "assri": "ASSRI",
-        "cssri": "CSSRI",
-        "ket": "Ketamine",
-        "mdma": "MDMA",
-        "psi": "Psilocybin",
-        "sal": "Saline"
-      },
-      "comments": "",
-      "refs": [
-        {
-          "citation": "",
-          "bibkey": ""
-        }
-      ],
-      "files": [
-        [
-          "aboharb2025",
-          "5meo",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "6fdet",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "assri",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "cssri",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "ket",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "mdma",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "psi",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "aboharb2025",
-          "sal",
-          "allenccfv3",
-          "region"
-        ]
-      ],
-      "aux_files": {
-        "regionmapping": {
-          "format": "regionmapping",
-          "fname": "source-aboharb2025_regionmapping.csv",
-          "rel_path": "aboharb2025",
-          "checksum": "428fd5724c5043a77e79fb187a63d01d",
-          "url": {
-            "osf": "4u8kx",
-            "original": ""
-          },
-          "comments": ""
-        }
-      }
-    },
-    {
-      "source": "ibl2025",
-      "name": "ibl2025",
-      "description": "",
-      "file_desc": {
-        "behtask": "Behavioral task",
-        "ephys": "Electrophysiology"
-      },
-      "comments": "",
-      "refs": [
-        {
-          "citation": "",
-          "bibkey": ""
-        }
-      ],
-      "files": [
-        [
-          "ibl2025",
-          "behtask",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "ibl2025",
-          "ephys",
-          "allenccfv3",
-          "region"
-        ]
-      ],
-      "aux_files": {
-        "regionmapping": {
-          "format": "regionmapping",
-          "fname": "source-ibl2025_regionmapping.csv",
-          "rel_path": "ibl2025",
-          "checksum": "41ae7b8242a454ad1cce101ad2b23b1d",
-          "url": {
-            "osf": "gxedp",
-            "original": ""
-          },
-          "comments": ""
-        }
-      }
-    },
-    {
-      "source": "ji2021",
-      "name": "ji2021",
-      "description": "",
-      "file_desc": {
-        "ji2021": "Ji 2021",
-        "kirst2020": "Kirst 2020",
-        "todorov2020": "Todorov 2020"
-      },
-      "comments": "",
-      "refs": [
-        {
-          "citation": "",
-          "bibkey": ""
-        }
-      ],
-      "files": [
-        [
-          "ji2021",
-          "ji2021",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "ji2021",
-          "kirst2020",
-          "allenccfv3",
-          "region"
-        ],
-        [
-          "ji2021",
-          "todorov2020",
-          "allenccfv3",
-          "region"
-        ]
-      ],
-      "aux_files": {
-        "regionmapping": {
-          "format": "regionmapping",
-          "fname": "source-ji2021_regionmapping.csv",
-          "rel_path": "ji2021",
-          "checksum": "41ee7295dd3e82c504b163c6fd2674fd",
-          "url": {
-            "osf": "mx4rv",
+            "osf": "8z4yf",
             "original": ""
           },
           "comments": ""

--- a/neuromaps_mouse/datasets/data/annotations.json
+++ b/neuromaps_mouse/datasets/data/annotations.json
@@ -1052,6 +1052,650 @@
       },
       "tags": [],
       "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homipsiqc211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homipsiqc211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "fd3a02e27c852372e23e67753595a095",
+      "url": {
+        "osf": "8z7me",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homipsiqc291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homipsiqc291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "0547f9b0ba84b9aec693c4b49ed9b205",
+      "url": {
+        "osf": "rmp49",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homipsiorig211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homipsiorig211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "6faabffb89a4f6c70457fc1c0743d55d",
+      "url": {
+        "osf": "xa357",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homipsiorig291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homipsiorig291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "8296c3de60384b763851be22ee3a5a95",
+      "url": {
+        "osf": "5x62q",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homcontraqc211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homcontraqc211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "ac32d5568bd04280352edc79813dbad0",
+      "url": {
+        "osf": "dwgkz",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homcontraqc291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homcontraqc291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "d38ad8d8cf9408ef1309e16962f902e9",
+      "url": {
+        "osf": "p2agt",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homcontraorig211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homcontraorig211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "aaf6713adec9822a1e3283b6229cb41d",
+      "url": {
+        "osf": "cn73u",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "homcontraorig291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-homcontraorig291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "694a26861193ad48fa4a490b08e309ea",
+      "url": {
+        "osf": "btrnk",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxipsiqc211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxipsiqc211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "93540b1b2d82101b2307b890f3aa7625",
+      "url": {
+        "osf": "p3gau",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxipsiqc291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxipsiqc291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "570f7b6bf3eb15462c5f16c174e80a66",
+      "url": {
+        "osf": "wfn69",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxipsiorig211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxipsiorig211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "1c502cf17e40c139873c3485b9b4d235",
+      "url": {
+        "osf": "5648k",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxipsiorig291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxipsiorig291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "c47878ef7cfd6c8863a971aa1a616dd8",
+      "url": {
+        "osf": "4gczr",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxcontraqc211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxcontraqc211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "7bd5bda860201decd013f7df848ac380",
+      "url": {
+        "osf": "qzm36",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxcontraqc291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxcontraqc291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "ec6b956da95fe8a62397441dd203a993",
+      "url": {
+        "osf": "4ju53",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxcontraorig211",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxcontraorig211_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r211_regionmapping.csv",
+      "checksum": "5d4a549a208089539c97192f607fa1dd",
+      "url": {
+        "osf": "p4xb7",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "nathan2026",
+      "desc": "voxcontraorig291",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-nathan2026_desc-voxcontraorig291_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "nathan2026",
+      "regionmapping": "source-nathan2026_r291_regionmapping.csv",
+      "checksum": "c9367a9b91e1e5880b34122360223153",
+      "url": {
+        "osf": "a8nmw",
+        "original": ""
+      },
+      "tags": [
+        "connectome"
+      ],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calpvallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calpvallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "66f98c60e8b98054cdb95fe2a010e369",
+      "url": {
+        "osf": "vg2h7",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calpvallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calpvallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "894daece8ef45909bfd943c3628e9d26",
+      "url": {
+        "osf": "yu8g5",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calvipallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calvipallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "65644f9bbff8971cd18cf446a8625102",
+      "url": {
+        "osf": "f3e2v",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calvipallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calvipallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "63878d6438b4ba638db7e72579c21fe8",
+      "url": {
+        "osf": "h3zn7",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calslcallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calslcallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "2fc177a0726c0e4c7d026c770563041e",
+      "url": {
+        "osf": "faj35",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calslcallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calslcallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "04233840307b08d79e27f74637fa0304",
+      "url": {
+        "osf": "8jmz4",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calsomallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calsomallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "de0fd0a297e7287c207067b9ff75e6b3",
+      "url": {
+        "osf": "bx9de",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calsomallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calsomallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "11de7e87874b54c5c244224cde8f2d58",
+      "url": {
+        "osf": "mduj2",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calgliaallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calgliaallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "08846c94e4db52c763d4c68e14a5c54e",
+      "url": {
+        "osf": "3cxsd",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "calgliaallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-calgliaallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_cal_regionmapping.csv",
+      "checksum": "3e43aac322fe63daf692e0f6010954ad",
+      "url": {
+        "osf": "7tybv",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmripvallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmripvallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "5cb2d1718bd9af574b5e5ccf9639e944",
+      "url": {
+        "osf": "fn3cv",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmripvallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmripvallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "c49cf4e4a51dc5bd28a79cc9d360ddb9",
+      "url": {
+        "osf": "qj36d",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrivipallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrivipallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "d49b3e84ba7ee13e02d8aab4e46c37bd",
+      "url": {
+        "osf": "q47fz",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrivipallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrivipallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "d2d7e731bd1e7dedc95ea7c0e6dc11bf",
+      "url": {
+        "osf": "gwakb",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrislcallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrislcallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "3043e82fa87b9ac9cdbeffa642750ac2",
+      "url": {
+        "osf": "tec9v",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrislcallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrislcallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "239326461ea3c07783bac66754ecc49c",
+      "url": {
+        "osf": "bjpsg",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrisomallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrisomallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "3b03b7aaaaf32110bcb83a2cf304fd69",
+      "url": {
+        "osf": "3csme",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrisomallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrisomallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "de92c42be3a47ceaffaed4b72c10a49f",
+      "url": {
+        "osf": "f37ze",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrigliaallgsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrigliaallgsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "54b16d017c5a85903314222999797983",
+      "url": {
+        "osf": "ys6mt",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
+    },
+    {
+      "format": "matrix",
+      "source": "mandino2025",
+      "desc": "fmrigliaallnogsr",
+      "space": "allenccfv3",
+      "res": "region",
+      "fname": "source-mandino2025_desc-fmrigliaallnogsr_space-allenccfv3_res-region_matrix.csv",
+      "rel_path": "mandino2025",
+      "regionmapping": "source-mandino2025_fmri_regionmapping.csv",
+      "checksum": "745c5fae932beffa8575fe789aa248c0",
+      "url": {
+        "osf": "qrthv",
+        "original": ""
+      },
+      "tags": [],
+      "comments": ""
     }
   ]
 }

--- a/neuromaps_mouse/datasets/utils.py
+++ b/neuromaps_mouse/datasets/utils.py
@@ -141,263 +141,13 @@ def _filter_annots_by_keys(keys_dict):
     return filtered
 
 
-def _check_json(osfstorage_data, overwrite=False):
-    """
-    Check for errors in meta.json.
-
-    For internal use only.
-
-    Returns
-    -------
-    None
-    """
-    # reload the datasets and meta json files
-    from rich.console import Console
-    import importlib.resources
-
-    console = Console()
-
-    # Load JSON files
-    MOUSEMAPS_ATLASES = _load_resource_json("datasets/data/atlases.json")["atlases"]
-    MOUSEMAPS_ANNOTS = _load_resource_json("datasets/data/annotations.json")[
-        "annotations"
-    ]
-    MOUSEMAPS_ANNOTS_META = _load_resource_json("datasets/data/annotations-meta.json")[
-        "annotations-meta"
-    ]
-
-    # Track if any changes were made
-    atlases_updated = False
-    annots_updated = False
-    annots_meta_updated = False
-
-    console.print("ATLASES")
-    for atlas_k, atlas_v in MOUSEMAPS_ATLASES.items():
-        console.print(f"{atlas_k} >")
-        for file_k, file_v in atlas_v["files"].items():
-            console.print(f"  {file_k} >")
-            if file_v["checksum"] == osfstorage_data[file_v["fname"]]["md5"]:
-                console.print("    [bold green]✓[/bold green] checksum")
-            else:
-                if overwrite:
-                    file_v["checksum"] = osfstorage_data[file_v["fname"]]["md5"]
-                    atlases_updated = True
-                    console.print("    [bold yellow]↻[/bold yellow] checksum updated")
-                else:
-                    console.print(
-                        f"    [bold red]x[/bold red] "
-                        f"checksum local: {file_v['checksum']} "
-                        f"remote: {osfstorage_data[file_v['fname']]['md5']}"
-                    )
-
-            if file_v["url"]["osf"] == osfstorage_data[file_v["fname"]]["guid"]:
-                console.print("    [bold green]✓[/bold green] url")
-            else:
-                if overwrite:
-                    file_v["url"]["osf"] = osfstorage_data[file_v["fname"]]["guid"]
-                    atlases_updated = True
-                    console.print("    [bold yellow]↻[/bold yellow] url updated")
-                else:
-                    console.print(
-                        f"    [bold red]x[/bold red] "
-                        f"url local: {file_v['url']['osf']} "
-                        f"remote: {osfstorage_data[file_v['fname']]['guid']}"
-                    )
-
-    console.print("\nANNOTS_META")
-    for annot_meta in MOUSEMAPS_ANNOTS_META:
-        console.print(f"{annot_meta['source']} {annot_meta['name']} >")
-        console.print(r"  \[annot files] >")
-        for file_v in annot_meta["files"]:
-            console.print(f"    {'-'.join(file_v)} >")
-            try:
-                matched = _match_annots_by_tuple([tuple(file_v)])
-            except ValueError:
-                console.print(f"      [bold red]x[/bold red] json {matched = }")
-
-            if len(matched) == 1:
-                console.print("      [bold green]✓[/bold green] json")
-            else:
-                console.print(f"      [bold red]x[/bold red] json {len(matched) = }")
-
-        console.print(r"  \[aux files] >")
-        for aux_k, aux_v in annot_meta["aux_files"].items():
-            console.print(f"    {aux_k} >")
-
-            if not isinstance(aux_v, list):
-                aux_v = [aux_v]
-            for file_v in aux_v:
-                console.print(f"      {file_v['fname']} >")
-                if file_v["fname"] not in osfstorage_data:
-                    console.print(
-                        f"        [bold red]x[/bold red] "
-                        f"{file_v['fname']} not found in osfstorage"
-                    )
-                    continue
-                if file_v["checksum"] == osfstorage_data[file_v["fname"]]["md5"]:
-                    console.print("        [bold green]✓[/bold green] checksum")
-                else:
-                    if overwrite:
-                        file_v["checksum"] = osfstorage_data[file_v["fname"]]["md5"]
-                        annots_meta_updated = True
-                        console.print(
-                            "        [bold yellow]↻[/bold yellow] checksum updated"
-                        )
-                    else:
-                        console.print(
-                            f"        [bold red]x[/bold red] "
-                            f"checksum local: {file_v['checksum']} "
-                            f"remote: {osfstorage_data[file_v['fname']]['md5']}"
-                        )
-                if file_v["url"]["osf"] == osfstorage_data[file_v["fname"]]["guid"]:
-                    console.print("        [bold green]✓[/bold green] url")
-                else:
-                    if overwrite:
-                        file_v["url"]["osf"] = osfstorage_data[file_v["fname"]]["guid"]
-                        annots_meta_updated = True
-                        console.print(
-                            "        [bold yellow]↻[/bold yellow] url updated"
-                        )
-                    else:
-                        console.print(
-                            f"        [bold red]x[/bold red] "
-                            f"url local: {file_v['url']['osf']} "
-                            f"remote: {osfstorage_data[file_v['fname']]['guid']}"
-                        )
-
-    console.print("\nANNOTS")
-    for annot in MOUSEMAPS_ANNOTS:
-        annotstr = "-".join(
-            [annot["source"], annot["desc"], annot["space"], annot["res"]]
-        )
-        console.print(f"  {annotstr} >")
-        if annot["fname"] not in osfstorage_data:
-            console.print(
-                f"        [bold red]x[/bold red] "
-                f"{annot['fname']} not found in osfstorage"
-            )
-            continue
-        if annot["checksum"] == osfstorage_data[annot["fname"]]["md5"]:
-            console.print("    [bold green]✓[/bold green] checksum")
-        else:
-            if overwrite:
-                annot["checksum"] = osfstorage_data[annot["fname"]]["md5"]
-                annots_updated = True
-                console.print("    [bold yellow]↻[/bold yellow] checksum updated")
-            else:
-                console.print(
-                    f"    [bold red]x[/bold red] "
-                    f"checksum local: {annot['checksum']} "
-                    f"remote: {osfstorage_data[annot['fname']]['md5']}"
-                )
-        if annot["url"]["osf"] == osfstorage_data[annot["fname"]]["guid"]:
-            console.print("    [bold green]✓[/bold green] url")
-        else:
-            if overwrite:
-                annot["url"]["osf"] = osfstorage_data[annot["fname"]]["guid"]
-                annots_updated = True
-                console.print("    [bold yellow]↻[/bold yellow] url updated")
-            else:
-                console.print(
-                    f"    [bold red]x[/bold red] "
-                    f"url local: {annot['url']['osf']} "
-                    f"remote: {osfstorage_data[annot['fname']]['guid']}"
-                )
-
-    # Write updated JSON files if changes were made
-    if atlases_updated:
-        atlases_data = {"atlases": MOUSEMAPS_ATLASES}
-        if getattr(importlib.resources, "files", None) is not None:
-            atlases_file = (
-                importlib.resources.files("neuromaps_mouse")
-                / "datasets/data/atlases.json"
-            )
-        else:
-            from pkg_resources import resource_filename
-
-            atlases_file = resource_filename(
-                "neuromaps_mouse", "datasets/data/atlases.json"
-            )
-        with open(atlases_file, "w") as f:
-            json.dump(atlases_data, f, indent=2)
-        console.print("\n[bold green]✓[/bold green] Updated atlases.json")
-    if annots_updated:
-        annots_data = {"annotations": MOUSEMAPS_ANNOTS}
-        if getattr(importlib.resources, "files", None) is not None:
-            annots_file = (
-                importlib.resources.files("neuromaps_mouse")
-                / "datasets/data/annotations.json"
-            )
-        else:
-            from pkg_resources import resource_filename
-
-            annots_file = resource_filename(
-                "neuromaps_mouse", "datasets/data/annotations.json"
-            )
-        with open(annots_file, "w") as f:
-            json.dump(annots_data, f, indent=2)
-        console.print("[bold green]✓[/bold green] Updated annotations.json")
-    if annots_meta_updated:
-        annots_meta_data = {"annotations-meta": MOUSEMAPS_ANNOTS_META}
-        if getattr(importlib.resources, "files", None) is not None:
-            annots_meta_file = (
-                importlib.resources.files("neuromaps_mouse")
-                / "datasets/data/annotations-meta.json"
-            )
-        else:
-            from pkg_resources import resource_filename
-
-            annots_meta_file = resource_filename(
-                "neuromaps_mouse", "datasets/data/annotations-meta.json"
-            )
-        with open(annots_meta_file, "w") as f:
-            json.dump(annots_meta_data, f, indent=2)
-        console.print("[bold green]✓[/bold green] Updated annotations-meta.json")
-
-    # Check for files in OSF storage that are not referenced in JSON files
-    console.print("\nFILES IN OSF STORAGE NOT REFERENCED IN JSON")
-
-    # Collect all filenames referenced in JSON files
-    json_files = set()
-
-    # Atlas files
-    for atlas_v in MOUSEMAPS_ATLASES.values():
-        for file_v in atlas_v["files"].values():
-            json_files.add(file_v["fname"])
-
-    # Annotation files
-    for annot in MOUSEMAPS_ANNOTS:
-        json_files.add(annot["fname"])
-
-    # Annotation meta aux files
-    for annot_meta in MOUSEMAPS_ANNOTS_META:
-        for aux_v in annot_meta["aux_files"].values():
-            if not isinstance(aux_v, list):
-                aux_v = [aux_v]
-            for file_v in aux_v:
-                json_files.add(file_v["fname"])
-
-    # Find files in OSF storage not in JSON
-    unreferenced_files = set(osfstorage_data.keys()) - json_files
-
-    if unreferenced_files:
-        for fname in sorted(unreferenced_files):
-            console.print(f"  [bold yellow]?[/bold yellow] {fname}")
-        console.print(
-            f"\n[bold yellow]Found {len(unreferenced_files)} "
-            f"unreferenced files in OSF storage[/bold yellow]"
-        )
-    else:
-        console.print(
-            "  [bold green]✓[/bold green] All OSF storage files are referenced in JSON"
-        )
-
-
 def _check_osfstorage():
     """
     Check for errors in OSF links.
 
     For internal use only.
+
+    osfstorage_data = _check_osfstorage()
 
     Returns
     -------
@@ -414,66 +164,229 @@ def _check_osfstorage():
     OSF_NODEID = "uryk3"
     OSF_URL = f"https://api.osf.io/v2/nodes/{OSF_NODEID}/files/osfstorage/"
 
-    def _get_file_href(d):
-        return d["relationships"]["files"]["links"]["related"]["href"]
+    def _get_file_href(entry):
+        return entry["relationships"]["files"]["links"]["related"]["href"]
 
-    def _get_full_data(url):
-        # handles pagination
+    def _get_paginated(url):
         resp = requests.get(url).json()
-        ret = resp["data"]
+        results = resp["data"]
         while resp["links"].get("next"):
-            href = resp["links"]["next"]
-            resp = requests.get(href).json()
-            ret.extend(resp["data"])
-        return ret
+            resp = requests.get(resp["links"]["next"]).json()
+            results.extend(resp["data"])
+        return results
+
+    def _process_file(file_entry):
+        attrs = file_entry["attributes"]
+        console.print(f"      {attrs['guid']}")
+        console.print(f"      {attrs['extra']['hashes']['md5']}")
+        if not attrs["guid"]:
+            r = requests.get(
+                file_entry["links"]["self"] + "?create_guid=true",
+                allow_redirects=True,
+            )
+            console.print(f"      {r.url}")
+        osfstorage_data[attrs["name"]] = {
+            "guid": attrs["guid"],
+            "md5": attrs["extra"]["hashes"]["md5"],
+        }
 
     for kind in requests.get(OSF_URL).json()["data"]:
         kind_path = kind["attributes"]["materialized_path"]
         console.print(f"{kind_path} >")
         if kind_path == "/atlases/":
-            for source in _get_full_data(_get_file_href(kind)):
+            for source in _get_paginated(_get_file_href(kind)):
                 source_path = source["attributes"]["materialized_path"]
                 console.print(f"  {source_path.removeprefix(kind_path)} >")
-                for version in _get_full_data(_get_file_href(source)):
+                for version in _get_paginated(_get_file_href(source)):
                     version_path = version["attributes"]["materialized_path"]
                     console.print(f"  {version_path.removeprefix(source_path)} >")
-                    for file in _get_full_data(_get_file_href(version)):
-                        file_path = file["attributes"]["materialized_path"]
-                        console.print(f"    {file_path.removeprefix(version_path)} >")
-                        console.print(f"      {file['attributes']['guid']}")
-                        console.print(
-                            f"      {file['attributes']['extra']['hashes']['md5']}"
-                        )
-                        if not file["attributes"]["guid"]:
-                            requests.get(
-                                f"https://osf.io/{OSF_NODEID}/files/osfstorage{file['attributes']['path']}"
-                            )
-                        osfstorage_data[file["attributes"]["name"]] = {
-                            "guid": file["attributes"]["guid"],
-                            "md5": file["attributes"]["extra"]["hashes"]["md5"],
-                        }
+                    for file_entry in _get_paginated(_get_file_href(version)):
+                        fpath = file_entry["attributes"]["materialized_path"]
+                        console.print(f"    {fpath.removeprefix(version_path)} >")
+                        _process_file(file_entry)
         elif kind_path == "/annotations/":
-            for source in _get_full_data(_get_file_href(kind)):
+            for source in _get_paginated(_get_file_href(kind)):
                 source_path = source["attributes"]["materialized_path"]
                 console.print(f"  {source_path.removeprefix(kind_path)} >")
-                for file in _get_full_data(_get_file_href(source)):
-                    file_path = file["attributes"]["materialized_path"]
-                    console.print(f"    {file_path.removeprefix(source_path)} >")
-                    console.print(f"      {file['attributes']['guid']}")
-                    console.print(
-                        f"      {file['attributes']['extra']['hashes']['md5']}"
-                    )
-                    if not file["attributes"]["guid"]:
-                        requests.get(
-                            f"https://osf.io/{OSF_NODEID}/files/osfstorage{file['attributes']['path']}"
-                        )
-                    osfstorage_data[file["attributes"]["name"]] = {
-                        "guid": file["attributes"]["guid"],
-                        "md5": file["attributes"]["extra"]["hashes"]["md5"],
-                    }
+                for file_entry in _get_paginated(_get_file_href(source)):
+                    fpath = file_entry["attributes"]["materialized_path"]
+                    console.print(f"    {fpath.removeprefix(source_path)} >")
+                    _process_file(file_entry)
         else:
             raise ValueError(f"Unknown kind_path={kind_path}")
     return osfstorage_data
+
+
+def _write_resource_json(relative_path, data):
+    """Write data dict to a package resource JSON file."""
+    if getattr(importlib.resources, "files", None) is not None:
+        filepath = importlib.resources.files("neuromaps_mouse") / relative_path
+    else:
+        from pkg_resources import resource_filename
+
+        filepath = resource_filename("neuromaps_mouse", relative_path)
+    with open(filepath, "w") as f:
+        json.dump(data, f, indent=2)
+
+
+def _validate_file_fields(file_entry, osfstorage_data, overwrite, console, indent="    "):
+    """Validate checksum and URL of a file entry against OSF storage data.
+
+    Returns True if any field was updated, None if file not in osfstorage_data.
+    """
+    fname = file_entry["fname"]
+    if fname not in osfstorage_data:
+        console.print(f"{indent}[bold red]x[/bold red] {fname} not found in osfstorage")
+        return None
+
+    updated = False
+    remote = osfstorage_data[fname]
+
+    if file_entry["checksum"] == remote["md5"]:
+        console.print(f"{indent}[bold green]✓[/bold green] checksum")
+    elif overwrite:
+        file_entry["checksum"] = remote["md5"]
+        updated = True
+        console.print(f"{indent}[bold yellow]↻[/bold yellow] checksum updated")
+    else:
+        console.print(
+            f"{indent}[bold red]x[/bold red] "
+            f"checksum local: {file_entry['checksum']} remote: {remote['md5']}"
+        )
+
+    if file_entry["url"]["osf"] == remote["guid"]:
+        console.print(f"{indent}[bold green]✓[/bold green] url")
+    elif overwrite:
+        file_entry["url"]["osf"] = remote["guid"]
+        updated = True
+        console.print(f"{indent}[bold yellow]↻[/bold yellow] url updated")
+    else:
+        console.print(
+            f"{indent}[bold red]x[/bold red] "
+            f"url local: {file_entry['url']['osf']} remote: {remote['guid']}"
+        )
+
+    return updated
+
+
+def _check_json(osfstorage_data, overwrite=False):
+    """
+    Check for errors in meta.json.
+
+    For internal use only.
+
+    _check_json(osfstorage_data)
+
+    Returns
+    -------
+    None
+    """
+    from rich.console import Console
+
+    console = Console()
+
+    MOUSEMAPS_ATLASES = _load_resource_json("datasets/data/atlases.json")["atlases"]
+    MOUSEMAPS_ANNOTS = _load_resource_json("datasets/data/annotations.json")[
+        "annotations"
+    ]
+    MOUSEMAPS_ANNOTS_META = _load_resource_json("datasets/data/annotations-meta.json")[
+        "annotations-meta"
+    ]
+
+    atlases_updated = False
+    annots_updated = False
+    annots_meta_updated = False
+
+    console.print("ATLASES")
+    for atlas_k, atlas_v in MOUSEMAPS_ATLASES.items():
+        console.print(f"{atlas_k} >")
+        for file_k, file_v in atlas_v["files"].items():
+            console.print(f"  {file_k} >")
+            if _validate_file_fields(file_v, osfstorage_data, overwrite, console, "    "):
+                atlases_updated = True
+
+    console.print("\nANNOTS_META")
+    for annot_meta in MOUSEMAPS_ANNOTS_META:
+        console.print(f"{annot_meta['source']} {annot_meta['name']} >")
+        console.print(r"  \[annot files] >")
+        for file_v in annot_meta["files"]:
+            console.print(f"    {'-'.join(file_v)} >")
+            try:
+                matched = _match_annots_by_tuple([tuple(file_v)])
+            except ValueError:
+                console.print("      [bold red]x[/bold red] json not found")
+            else:
+                if len(matched) == 1:
+                    console.print("      [bold green]✓[/bold green] json")
+                else:
+                    console.print(f"      [bold red]x[/bold red] json {len(matched) = }")
+
+        console.print(r"  \[aux files] >")
+        for aux_k, aux_v in annot_meta["aux_files"].items():
+            console.print(f"    {aux_k} >")
+            if not isinstance(aux_v, list):
+                aux_v = [aux_v]
+            for file_v in aux_v:
+                console.print(f"      {file_v['fname']} >")
+                if _validate_file_fields(
+                    file_v, osfstorage_data, overwrite, console, "        "
+                ):
+                    annots_meta_updated = True
+
+    console.print("\nANNOTS")
+    for annot in MOUSEMAPS_ANNOTS:
+        annotstr = "-".join(
+            [annot["source"], annot["desc"], annot["space"], annot["res"]]
+        )
+        console.print(f"  {annotstr} >")
+        if _validate_file_fields(annot, osfstorage_data, overwrite, console, "    "):
+            annots_updated = True
+
+    if atlases_updated:
+        _write_resource_json("datasets/data/atlases.json", {"atlases": MOUSEMAPS_ATLASES})
+        console.print("\n[bold green]✓[/bold green] Updated atlases.json")
+    if annots_updated:
+        _write_resource_json(
+            "datasets/data/annotations.json", {"annotations": MOUSEMAPS_ANNOTS}
+        )
+        console.print("[bold green]✓[/bold green] Updated annotations.json")
+    if annots_meta_updated:
+        _write_resource_json(
+            "datasets/data/annotations-meta.json",
+            {"annotations-meta": MOUSEMAPS_ANNOTS_META},
+        )
+        console.print("[bold green]✓[/bold green] Updated annotations-meta.json")
+
+    # Check for unreferenced files
+    console.print("\nFILES IN OSF STORAGE NOT REFERENCED IN JSON")
+    json_files = set()
+    for atlas_v in MOUSEMAPS_ATLASES.values():
+        for file_v in atlas_v["files"].values():
+            json_files.add(file_v["fname"])
+    for annot in MOUSEMAPS_ANNOTS:
+        json_files.add(annot["fname"])
+    for annot_meta in MOUSEMAPS_ANNOTS_META:
+        for aux_v in annot_meta["aux_files"].values():
+            if not isinstance(aux_v, list):
+                aux_v = [aux_v]
+            for file_v in aux_v:
+                json_files.add(file_v["fname"])
+
+    unreferenced_files = set(osfstorage_data.keys()) - json_files
+    if unreferenced_files:
+        for fname in sorted(unreferenced_files):
+            console.print(f"  [bold yellow]?[/bold yellow] {fname}")
+        console.print(
+            f"\n[bold yellow]Found {len(unreferenced_files)} "
+            f"unreferenced files in OSF storage[/bold yellow]"
+        )
+    else:
+        console.print(
+            "  [bold green]✓[/bold green] All OSF storage files are referenced in JSON"
+        )
+
+
+
 
 
 def _gen_doc_listofmaps_rst(listofmaps_file):
@@ -486,69 +399,113 @@ def _gen_doc_listofmaps_rst(listofmaps_file):
         "annotations-meta"
     ]
 
-    output = []
+    sections = []
 
-    output += [
+    for annot_meta in MOUSEMAPS_ANNOTS_META:
+        lines = []
+        title = f"{annot_meta['name']} ({annot_meta['source']})"
+        lines += [
+            title,
+            "=" * len(title),
+            "",
+            annot_meta["description"],
+            "",
+        ]
+
+        if annot_meta.get("warning"):
+            lines += [
+                f".. warning:: {annot_meta['warning']}",
+                "",
+            ]
+
+        # File list as a table: description, format, fetch key
+        lines += [
+            "**Available files**",
+            "",
+            ".. list-table::",
+            "   :header-rows: 1",
+            "",
+            "   * - Description",
+            "     - Format",
+            "     - Key",
+        ]
+        for file_tuple in annot_meta["files"]:
+            curr_annot = _match_annots_by_tuple(tuple(file_tuple))[0]
+            desc = annot_meta["file_desc"][curr_annot["desc"]]
+            fmt = curr_annot["format"]
+            key_str = ", ".join(
+                f"'{curr_annot[k]}'" for k in ("source", "desc", "space", "res")
+            )
+            lines += [
+                f"   * - {desc}",
+                f"     - {fmt}",
+                f"     - ``({key_str})``",
+            ]
+        lines.append("")
+
+        # Unified how-to-use section
+        first_annot = _match_annots_by_tuple(tuple(annot_meta["files"][0]))[0]
+        first_key = ", ".join(
+            f"'{first_annot[k]}'" for k in ("source", "desc", "space", "res")
+        )
+        lines += [
+            "**How to use**",
+            "",
+            ".. code:: python",
+            "",
+            "    # fetch a specific annotation",
+            f"    fetch_annotation(({first_key}))",
+            "",
+            "    # file location",
+            f"    # $MOUSEMAPS_DATA/{first_annot['rel_path']}",
+            "",
+        ]
+
+        # List all region mapping files from aux_files
+        aux = annot_meta.get("aux_files", {})
+        regionmaps = aux.get("regionmapping", [])
+        if not isinstance(regionmaps, list):
+            regionmaps = [regionmaps]
+        if regionmaps:
+            lines.append("    # region mapping files")
+            for rm in regionmaps:
+                lines.append(f"    # {rm['fname']}")
+            lines.append("")
+
+        # List all feature mapping files from aux_files
+        featmaps = aux.get("featuremapping", [])
+        if not isinstance(featmaps, list):
+            featmaps = [featmaps]
+        if featmaps:
+            lines.append("    # feature mapping files")
+            for fm in featmaps:
+                lines.append(f"    # {fm['fname']}")
+            lines.append("")
+
+        valid_refs = [
+            ref for ref in annot_meta["refs"]
+            if ref.get("bibkey") not in ("", None)
+        ]
+        if valid_refs:
+            lines += [
+                "**References**",
+                "",
+            ]
+            for ref in valid_refs:
+                lines.append(f"    - {ref['citation']}")
+
+        sections.append("\n".join(lines))
+
+    header = "\n".join([
         ".. _listofmaps:",
         "",
         "------------",
         "List of Maps",
         "------------",
-        "This is a complete list of maps available in the `neuromaps_mouse` package. ",
-        "\n----\n",
-    ]
+        "This is a complete list of maps available in the `neuromaps_mouse` package.",
+    ])
 
-    for annot_meta in MOUSEMAPS_ANNOTS_META:
-        title = f"{annot_meta['name']} ({annot_meta['source']})"
-        output += [
-            title,
-            "=" * len(title),
-            "",
-            "**Full description**",
-            "",
-            f"{annot_meta['description']}",
-            "",
-        ]
-
-        for file in annot_meta["files"]:
-            curr_annot = _match_annots_by_tuple(tuple(file))[0]
-            file_title = "-".join(file)
-            key_str = ", ".join(
-                [f"'{curr_annot[k]}'" for k in ["source", "desc", "space", "res"]])
-            output += [
-                file_title,
-                "-" * len(file_title),
-                "",
-                f"**Description**: {annot_meta['file_desc'][curr_annot['desc']]}",
-                "",
-                f"**Format**: {curr_annot['format']}",
-                "",
-                "**How to use**",
-                "",
-                ".. code:: python",
-                "",
-                "    # get annotation",
-                f"    fetch_annotation(({key_str}))",
-                "",
-                "    # file location",
-                f"    # $MOUSEMAPS_DATA/{curr_annot['rel_path']}",
-                "",
-                "    # file name",
-                f"    # {curr_annot['fname']}",
-                "",
-                "    # region mapping file",
-                f"    # {curr_annot['regionmapping']}",
-                "",
-            ]
-
-        output.append("**References**")
-        for bib_item in annot_meta["refs"]:
-            if bib_item["bibkey"] not in ["", None]:
-                output += [f"    - {bib_item['citation']}"]
-
-        output.append("\n----\n")
-
-    output = output[:-1]
+    separator = "\n\n----\n\n"
 
     with open(listofmaps_file, "w") as dst:
-        dst.write("\n".join(output))
+        dst.write(header + separator + separator.join(sections) + "\n")

--- a/neuromaps_mouse/images.py
+++ b/neuromaps_mouse/images.py
@@ -1,149 +1,61 @@
-"""Functions for loading and remapping data."""
-
-import numpy as np
-import pandas as pd
-
-from neuromaps_mouse.datasets.utils import get_data_dir
-from neuromaps_mouse.datasets.annotations import _match_annots_by_tuple
+"""Functions for image data fetching and loading."""
 
 
-def load_nifti():
+def parcellate_image(image, annotation, **kwargs):
+    """Parcellate an image using an annotation.
+
+    Parameters
+    ----------
+    image :
+        Input image data.
+    annotation :
+        Annotation to use for parcellation.
+    **kwargs :
+        Additional keyword arguments.
+
+    Returns
+    -------
+    parcellated :
+        Parcellated image data.
+    """
     pass
 
 
-def load_image_data():
+def register_image(image, target, **kwargs):
+    """Register an image to a target space.
+
+    Parameters
+    ----------
+    image :
+        Input image data.
+    target :
+        Target space or image for registration.
+    **kwargs :
+        Additional keyword arguments.
+
+    Returns
+    -------
+    registered :
+        Registered image data.
+    """
     pass
 
 
-def _remap_region_data(
-    original_values, value_format, regionmapping, target_column, hemi=None
-):
-    if hemi is not None:
-        if hemi not in ["left", "right"]:
-            raise ValueError(
-                f"Invalid hemi value: {hemi}. Should be one of ['left', 'right']"
-            )
-        regionmapping = regionmapping[regionmapping["hemi"] == hemi]
-        indices_hemi = regionmapping.index.tolist()
-        regionmapping = regionmapping.reset_index(drop=True)
-        if value_format == "matrix":
-            original_values = original_values[np.ix_(indices_hemi, indices_hemi)]
-        else:
-            original_values = original_values[indices_hemi, :]
+def transform_image(image, transform, **kwargs):
+    """Transform an image using a spatial transform.
 
-    # drop not-mapped regions
-    has_null = regionmapping[target_column].isnull().any()
+    Parameters
+    ----------
+    image :
+        Input image data.
+    transform :
+        Transform to apply.
+    **kwargs :
+        Additional keyword arguments.
 
-    # remove the null values
-    if has_null:
-        regionmapping_nona = regionmapping.dropna(subset=target_column, axis=0)
-        indices_nona = regionmapping_nona.index.tolist()
-        regionmapping_nona = regionmapping_nona.reset_index(drop=True)
-        if value_format == "matrix":
-            original_values_nona = original_values[np.ix_(indices_nona, indices_nona)]
-        else:
-            original_values_nona = original_values[indices_nona, :]
-    else:
-        regionmapping_nona = regionmapping
-        original_values_nona = original_values
-
-    # average the duplicate regions
-    has_duplicated = regionmapping_nona[target_column].duplicated().any()
-
-    if has_duplicated:
-        if value_format == "matrix":
-            raise ValueError(
-                "Duplicated regions in regionmapping, but annotation format is matrix"
-            )
-        indices_dup = (
-            regionmapping_nona.groupby(target_column)
-            .apply(lambda x: x.index.tolist())
-            .tolist()
-        )
-        original_values_nona_dedup = np.array(
-            [
-                np.mean(original_values_nona[indices, :], axis=0)
-                for indices in indices_dup
-            ]
-        )
-        regions_nona_dedup = list(
-            regionmapping_nona.groupby(target_column).groups.keys()
-        )
-    else:
-        regions_nona_dedup = regionmapping_nona[target_column].tolist()
-        original_values_nona_dedup = original_values_nona
-
-    return original_values_nona_dedup, regions_nona_dedup
-
-
-def load_region_data(
-    annotation, return_original=False, remap_kws=None, data_dir=None, verbose=1
-):
-    if annotation[-1] != "region":
-        raise ValueError(f"Annotation {annotation} is not a region annotation")
-
-    data_dir = get_data_dir(data_dir=data_dir)
-
-    annotation_full = _match_annots_by_tuple(annotation)[0]
-
-    # TODO check if the file exists, if not, download it
-
-    original_values_path = (
-        data_dir
-        / "annotations"
-        / annotation_full["rel_path"]
-        / annotation_full["fname"]
-    )
-    regionmapping_path = (
-        data_dir
-        / "annotations"
-        / annotation_full["rel_path"]
-        / annotation_full["regionmapping"]
-    )
-
-    # original_values = np.loadtxt(
-    #     data_dir
-    #     / "annotations"
-    #     / annotation_full["rel_path"]
-    #     / annotation_full["fname"],
-    #     delimiter=",",
-    # )
-    regionmapping = pd.read_csv(regionmapping_path)
-
-    if annotation_full["format"] == "scalar":
-        original_values = np.loadtxt(original_values_path, delimiter=",")[:, np.newaxis]
-        assert original_values.shape == (len(regionmapping), 1)
-    elif annotation_full["format"] == "tabular":
-        original_values = pd.read_csv(original_values_path, header=0)
-        tabular_header = original_values.columns.tolist()
-        original_values = original_values.to_numpy()
-        assert original_values.shape[0] == len(regionmapping)
-    elif annotation_full["format"] == "matrix":
-        assert (
-            original_values.shape[0] == original_values.shape[1] == len(regionmapping)
-        )
-
-    if return_original:
-        if annotation_full["format"] == "tabular":
-            return (
-                original_values,
-                regionmapping["original_region"].tolist(),
-                tabular_header,
-            )
-        else:
-            return original_values, regionmapping["original_region"].tolist()
-
-    remap_dict = remap_kws or {}
-
-    original_values_nona_dedup, region_nona_dedup = _remap_region_data(
-        original_values,
-        annotation_full["format"],
-        regionmapping,
-        "allenccfv3_acronym",
-        **remap_dict,
-    )
-
-    if annotation_full["format"] == "tabular":
-        return original_values_nona_dedup, region_nona_dedup, tabular_header
-    else:
-        return original_values_nona_dedup, region_nona_dedup
+    Returns
+    -------
+    transformed :
+        Transformed image data.
+    """
+    pass

--- a/neuromaps_mouse/io.py
+++ b/neuromaps_mouse/io.py
@@ -1,0 +1,176 @@
+"""Functions for loading and remapping data."""
+
+import numpy as np
+import pandas as pd
+
+from neuromaps_mouse.datasets.utils import get_data_dir
+from neuromaps_mouse.datasets.annotations import _match_annots_by_tuple
+
+
+def load_nifti():
+    """Load a NIfTI image file."""
+    pass
+
+
+def load_image_data():
+    """Load image-format annotation data."""
+    pass
+
+
+def _remap_region_data(
+    original_values, value_format, regionmapping, target_column, hemi=None
+):
+    if hemi is not None:
+        if hemi not in ["left", "right"]:
+            raise ValueError(
+                f"Invalid hemi value: {hemi}. Should be one of ['left', 'right']"
+            )
+        regionmapping = regionmapping[regionmapping["hemi"] == hemi]
+        indices_hemi = regionmapping.index.tolist()
+        regionmapping = regionmapping.reset_index(drop=True)
+        if value_format == "matrix":
+            original_values = original_values[np.ix_(indices_hemi, indices_hemi)]
+        else:
+            original_values = original_values[indices_hemi, :]
+
+    # drop not-mapped regions
+    has_null = regionmapping[target_column].isnull().any()
+
+    # remove the null values
+    if has_null:
+        regionmapping_nona = regionmapping.dropna(subset=target_column, axis=0)
+        indices_nona = regionmapping_nona.index.tolist()
+        regionmapping_nona = regionmapping_nona.reset_index(drop=True)
+        if value_format == "matrix":
+            original_values_nona = original_values[np.ix_(indices_nona, indices_nona)]
+        else:
+            original_values_nona = original_values[indices_nona, :]
+    else:
+        regionmapping_nona = regionmapping
+        original_values_nona = original_values
+
+    # average the duplicate regions
+    has_duplicated = regionmapping_nona[target_column].duplicated().any()
+
+    if has_duplicated:
+        if value_format == "matrix":
+            raise ValueError(
+                "Duplicated regions in regionmapping, but annotation format is matrix"
+            )
+        indices_dup = (
+            regionmapping_nona.groupby(target_column)
+            .apply(lambda x: x.index.tolist())
+            .tolist()
+        )
+        original_values_nona_dedup = np.array(
+            [
+                np.mean(original_values_nona[indices, :], axis=0)
+                for indices in indices_dup
+            ]
+        )
+        regions_nona_dedup = list(
+            regionmapping_nona.groupby(target_column).groups.keys()
+        )
+    else:
+        regions_nona_dedup = regionmapping_nona[target_column].tolist()
+        original_values_nona_dedup = original_values_nona
+
+    return original_values_nona_dedup, regions_nona_dedup
+
+
+def load_region_data(
+    annotation, return_original=False, remap_kws=None, data_dir=None, verbose=1
+):
+    """Load and remap region-based annotation data.
+
+    Parameters
+    ----------
+    annotation : tuple
+        Annotation identifier tuple (source, desc, space, 'region').
+    return_original : bool, optional
+        If True, return data in original region space without remapping.
+        Default is False.
+    remap_kws : dict, optional
+        Keyword arguments passed to ``_remap_region_data``. Default is None.
+    data_dir : str or Path, optional
+        Base data directory. If None, uses the default. Default is None.
+    verbose : int, optional
+        Verbosity level. Default is 1.
+
+    Returns
+    -------
+    values : numpy.ndarray
+        Annotation values remapped to Allen CCFv3 regions.
+    regions : list of str
+        Corresponding region acronyms.
+    header : list of str, optional
+        Column names for tabular annotations (only returned for tabular format).
+    """
+    if annotation[-1] != "region":
+        raise ValueError(f"Annotation {annotation} is not a region annotation")
+
+    data_dir = get_data_dir(data_dir=data_dir)
+
+    annotation_full = _match_annots_by_tuple(annotation)[0]
+
+    # TODO check if the file exists, if not, download it
+
+    original_values_path = (
+        data_dir
+        / "annotations"
+        / annotation_full["rel_path"]
+        / annotation_full["fname"]
+    )
+    regionmapping_path = (
+        data_dir
+        / "annotations"
+        / annotation_full["rel_path"]
+        / annotation_full["regionmapping"]
+    )
+
+    # original_values = np.loadtxt(
+    #     data_dir
+    #     / "annotations"
+    #     / annotation_full["rel_path"]
+    #     / annotation_full["fname"],
+    #     delimiter=",",
+    # )
+    regionmapping = pd.read_csv(regionmapping_path)
+
+    if annotation_full["format"] == "scalar":
+        original_values = np.loadtxt(original_values_path, delimiter=",")[:, np.newaxis]
+        assert original_values.shape == (len(regionmapping), 1)
+    elif annotation_full["format"] == "tabular":
+        original_values = pd.read_csv(original_values_path, header=0)
+        tabular_header = original_values.columns.tolist()
+        original_values = original_values.to_numpy()
+        assert original_values.shape[0] == len(regionmapping)
+    elif annotation_full["format"] == "matrix":
+        assert (
+            original_values.shape[0] == original_values.shape[1] == len(regionmapping)
+        )
+
+    if return_original:
+        if annotation_full["format"] == "tabular":
+            return (
+                original_values,
+                regionmapping["original_region"].tolist(),
+                tabular_header,
+            )
+        else:
+            return original_values, regionmapping["original_region"].tolist()
+
+    remap_dict = remap_kws or {}
+
+    original_values_nona_dedup, region_nona_dedup = _remap_region_data(
+        original_values,
+        annotation_full["format"],
+        regionmapping,
+        "allenccfv3_acronym",
+        **remap_dict,
+    )
+
+    if annotation_full["format"] == "tabular":
+        return original_values_nona_dedup, region_nona_dedup, tabular_header
+    else:
+        return original_values_nona_dedup, region_nona_dedup

--- a/neuromaps_mouse/plotting.py
+++ b/neuromaps_mouse/plotting.py
@@ -10,7 +10,7 @@ from mpl_toolkits.axes_grid1.anchored_artists import AnchoredSizeBar
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 from neuromaps_mouse.datasets import fetch_allenccfv3
-from neuromaps_mouse.resampling import query_structure_graph_allenccfv3
+from neuromaps_mouse.regions import query_structure_graph_allenccfv3
 
 VIEW_TO_BASIS = {
     "coronal": np.array([1, 0, 0]),
@@ -444,7 +444,7 @@ def plot_allenccfv3_lightbox(
     regions,
     values,
     view="coronal",
-    slices=[1000, 2000, 3000],
+    slices=None,
     cmap="viridis",
     clim=None,
     cnorm=None,
@@ -536,6 +536,8 @@ def plot_allenccfv3_lightbox(
     ...     cbar_title='Expression Level'
     ... )
     """
+    if slices is None:
+        slices = [1000, 2000, 3000]
     if not isinstance(slices, list):
         slices = [slices]
     if figsize is None:
@@ -592,7 +594,7 @@ def plot_allenccfv3_lightbox(
         gridspec_kw={"wspace": 0},
     )
 
-    for i_ax, (ax, coord) in enumerate(zip(axes.flatten(), slices)):
+    for i_ax, (ax, _coord) in enumerate(zip(axes.flatten(), slices)):
         curr_bg_segs = bg_segs_list[i_ax]
         if curr_bg_segs is not None:
             curr_bg_segs = curr_bg_segs.discrete
@@ -668,4 +670,5 @@ def plot_allenccfv3_lightbox(
 
 
 def plot_allenccfv3_3d():
+    """Create a 3D surface visualization of Allen CCFv3 brain regions."""
     pass

--- a/neuromaps_mouse/regions.py
+++ b/neuromaps_mouse/regions.py
@@ -10,6 +10,26 @@ from neuromaps_mouse.datasets import fetch_allenccfv3
 def query_structure_graph_allenccfv3(
     data, in_col="acronym", out_col="all", data_dir=None, verbose=1
 ):
+    """Query the Allen CCFv3 structure graph.
+
+    Parameters
+    ----------
+    data : array-like
+        Input values to query (e.g., region acronyms or IDs).
+    in_col : str, optional
+        Column to index by. Default is 'acronym'.
+    out_col : str or list of str, optional
+        Column(s) to return. Use 'all' to return all columns. Default is 'all'.
+    data_dir : str or Path, optional
+        Base data directory. If None, uses the default. Default is None.
+    verbose : int, optional
+        Verbosity level. Default is 1.
+
+    Returns
+    -------
+    pandas.DataFrame or pandas.Series
+        Queried structure graph data.
+    """
     # this directly returns the dataframe by indexing, so no none/null input
     df_struct = pd.read_csv(
         fetch_allenccfv3(
@@ -25,6 +45,29 @@ def query_structure_graph_allenccfv3(
 def get_feature_allenccfv3(
     data, in_col="acronym", out_col="id", data_dir=None, verbose=1
 ):
+    """Get a feature value for each region from the Allen CCFv3 structure graph.
+
+    Unlike ``query_structure_graph_allenccfv3``, this function accepts None/NaN
+    values and returns None for those entries.
+
+    Parameters
+    ----------
+    data : array-like
+        Input values (may include None/NaN).
+    in_col : str, optional
+        Column to index by. Default is 'acronym'.
+    out_col : str, optional
+        Column to return values from. Default is 'id'.
+    data_dir : str or Path, optional
+        Base data directory. If None, uses the default. Default is None.
+    verbose : int, optional
+        Verbosity level. Default is 1.
+
+    Returns
+    -------
+    list
+        Feature values, with None for any None/NaN inputs.
+    """
     # this allows none/null input and returns a list
     df_struct = pd.read_csv(
         fetch_allenccfv3(
@@ -92,6 +135,26 @@ def _get_nearest_descendant_region_allenccfv3(
 
 
 def align_structures_allenccfv3(acronyms_fixed, acronyms_moving, debug=False):
+    """Align moving structures to fixed structures via ancestor matching.
+
+    For each region in ``acronyms_moving``, finds its nearest ancestor that
+    exists in ``acronyms_fixed``.
+
+    Parameters
+    ----------
+    acronyms_fixed : array-like of str
+        Target region acronyms (the fixed reference set).
+    acronyms_moving : array-like of str
+        Source region acronyms to align to the fixed set.
+    debug : bool, optional
+        If True, also compute descendant mappings and add them to the
+        returned DataFrame. Default is False.
+
+    Returns
+    -------
+    pandas.DataFrame
+        DataFrame for moving regions with an added 'id_ancestor_fixed' column.
+    """
     df_fixed = query_structure_graph_allenccfv3(
         acronyms_fixed,
         in_col="acronym",
@@ -138,12 +201,29 @@ def align_structures_allenccfv3(acronyms_fixed, acronyms_moving, debug=False):
 
 
 def match_structures_fuzzy_allenccfv3():
+    """Match structures using fuzzy string matching."""
     pass
 
 
 def visualize_structure_alignment_allenccfv3(
     acronyms_fixed, acronyms_moving, save_path=Path("./"), save_name="graphviz"
 ):
+    """Visualize the alignment between two sets of brain structures as a graph.
+
+    Generates a Graphviz SVG diagram showing the hierarchical relationship
+    between fixed and moving region sets. Requires Graphviz to be installed.
+
+    Parameters
+    ----------
+    acronyms_fixed : array-like of str
+        Fixed (reference) region acronyms, marked with a stop symbol in the graph.
+    acronyms_moving : array-like of str
+        Moving (source) region acronyms, marked with an arrow in the graph.
+    save_path : str or Path, optional
+        Directory to save output files. Default is current directory.
+    save_name : str, optional
+        Base filename (without extension) for the output files. Default is 'graphviz'.
+    """
     graphviz_path = shutil.which("dot")
     if graphviz_path is None:
         raise ValueError("Graphviz executable not found, please install graphviz")
@@ -187,7 +267,7 @@ def visualize_structure_alignment_allenccfv3(
         'edge [fontname="Arial", fontsize=10];',
     ]
 
-    for i, row in struct_csv_filtered.iterrows():
+    for _i, row in struct_csv_filtered.iterrows():
         curr_label = row["acronym"]
         if row["acronym"] in df_fixed["acronym"].tolist():
             curr_label += " ⏹️"
@@ -195,7 +275,7 @@ def visualize_structure_alignment_allenccfv3(
             curr_label += " ⬅️"
         graphviz_script.append(f'{row["id"]} [label="{curr_label}"]')
 
-    for i, row in struct_csv_filtered.iterrows():
+    for _i, row in struct_csv_filtered.iterrows():
         if row["acronym"] == "root":
             continue
         graphviz_script.append(f"    {row['parent_structure_id']} -> {row['id']}")

--- a/neuromaps_mouse/stats.py
+++ b/neuromaps_mouse/stats.py
@@ -2,4 +2,10 @@
 
 
 def correlation():
+    """Compute spatial correlation between two brain maps."""
+    pass
+
+
+def moran():
+    """Compute Moran's I spatial autocorrelation."""
     pass

--- a/neuromaps_mouse/transforms.py
+++ b/neuromaps_mouse/transforms.py
@@ -1,4 +1,0 @@
-
-
-def allenccfv3_to_allenccfv3():
-    pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
   "numpy",
   "scipy",
   "matplotlib",
-  "scikit-learn",
   "nibabel",
   "nilearn",
   "pandas",
@@ -34,21 +33,14 @@ dependencies = [
 dynamic=["version"]
 
 [project.optional-dependencies]
-docs = [
-  "sphinx",
-  "sphinx_rtd_theme",
-  "sphinx-gallery"
-]
 pyvista = [
   "vtk",
   "pyvista"
 ]
-numba = [
-  "numba"
-]
-style = [
-  "flake8",
-  "ruff"
+docs = [
+  "sphinx",
+  "sphinx_rtd_theme",
+  "sphinx-gallery"
 ]
 test = [
   "coverage",
@@ -56,7 +48,8 @@ test = [
   "pytest-cov",
 ]
 dev = [
-  "ipython"
+  "ipython",
+  "ruff"
 ]
 
 [project.urls]


### PR DESCRIPTION
This pull request introduces several improvements and refactorings to the documentation, dataset utilities, and image handling modules. The most significant changes are the migration of image and region data loading/remapping logic from `images.py` to a new `io.py` module, updates to the public API in `datasets`, and substantial enhancements to the documentation for both API structure and installation instructions.

**Codebase refactoring and API improvements:**

* Moved low-level data loading and remapping functions (`load_nifti`, `load_image_data`, `load_region_data`, `_remap_region_data`) from `images.py` to a new `io.py` module, clarifying the separation between I/O and higher-level image processing. (`[[1]](diffhunk://#diff-0d625b545b032037ce2889ae610f7345aa7b6292de09af2fe1960b9db131649aL1-R61)`, `[[2]](diffhunk://#diff-641a2734bc789c995aa25a9ae0d31f75c4b6579785cfd9b962811c729a3d089cR1-R176)`)
* Updated `datasets/__init__.py` to expose new utility functions `get_atlas_dir` and `get_annotation_dir` in the public API, and ensured all relevant imports are included. (`[[1]](diffhunk://#diff-6d714aa5b2392916bdc6e909d50b397435104746d774b3da176a1281ebc43fe3L3-R4)`, `[[2]](diffhunk://#diff-6d714aa5b2392916bdc6e909d50b397435104746d774b3da176a1281ebc43fe3R13-R14)`)
* Added docstrings and improved parameter documentation for `get_atlas_dir` and `fetch_allenccfv3` in `atlases.py` for clarity and consistency. (`[[1]](diffhunk://#diff-85cad847bd64ac6d49fb38f4a0940589ec7949b154a136a06d00fdd0ad23f442R11-R47)`, `[[2]](diffhunk://#diff-85cad847bd64ac6d49fb38f4a0940589ec7949b154a136a06d00fdd0ad23f442R78)`)
* Updated `plotting.py` to import `query_structure_graph_allenccfv3` from the new `regions` module instead of `resampling`. (`[neuromaps_mouse/plotting.pyL13-R13](diffhunk://#diff-3527e3c763af7d3eaeae264bf434f6c063be210a7e328f207a208f3358d0eb32L13-R13)`)

**Documentation improvements:**

* Overhauled the installation documentation to provide clear requirements, step-by-step installation instructions, and guidance for optional dependencies (notably Pyvista and VTK backend configuration). (`[docs/installation.rstL12-R69](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbL12-R69)`)
* Refactored and expanded the API reference in `api.rst`:
  - Reorganized sections for images, I/O, and regions, added explicit autosummary listings for key functions, and clarified module purposes. (`[[1]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68L58-R83)`, `[[2]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68L94-R120)`, `[[3]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68R147-L144)`)
* Made significant CSS improvements for the documentation theme, including better table rendering, sidebar highlighting, code block styling, and improved readability for parameter lists and API signatures. (`[docs/_static/theme_overrides.cssL1-R103](diffhunk://#diff-bffe98820c75f17b7530290680a5349d714b873c9fde7051d3b10f272fec2196L1-R103)`)

**Other improvements:**

* Improved and clarified the `See Also` section in the `fetch_annotation` docstring. (`[neuromaps_mouse/datasets/annotations.pyR138-L148](diffhunk://#diff-e659845952c8109aaf2fed0d78e86dc6f8c68076f3e9036132e8180480ffa9f9R138-L148)`)
* Simplified logic in `fetch_annotation` by removing an unused assignment. (`[neuromaps_mouse/datasets/annotations.pyL179-R179](diffhunk://#diff-e659845952c8109aaf2fed0d78e86dc6f8c68076f3e9036132e8180480ffa9f9L179-R179)`)

These changes collectively improve the organization, usability, and maintainability of the codebase and its documentation.

**References:**  
[[1]](diffhunk://#diff-0d625b545b032037ce2889ae610f7345aa7b6292de09af2fe1960b9db131649aL1-R61) [[2]](diffhunk://#diff-641a2734bc789c995aa25a9ae0d31f75c4b6579785cfd9b962811c729a3d089cR1-R176) [[3]](diffhunk://#diff-6d714aa5b2392916bdc6e909d50b397435104746d774b3da176a1281ebc43fe3L3-R4) [[4]](diffhunk://#diff-6d714aa5b2392916bdc6e909d50b397435104746d774b3da176a1281ebc43fe3R13-R14) [[5]](diffhunk://#diff-85cad847bd64ac6d49fb38f4a0940589ec7949b154a136a06d00fdd0ad23f442R11-R47) [[6]](diffhunk://#diff-85cad847bd64ac6d49fb38f4a0940589ec7949b154a136a06d00fdd0ad23f442R78) [[7]](diffhunk://#diff-3527e3c763af7d3eaeae264bf434f6c063be210a7e328f207a208f3358d0eb32L13-R13) [[8]](diffhunk://#diff-d9b149498982c0663c3b7170398773361ed5678f1a627e9c2fd8d2c955c563dbL12-R69) [[9]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68L58-R83) [[10]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68L94-R120) [[11]](diffhunk://#diff-0ee295c29def16f570f86378eff8ba37315e464d415e731d5d8ea2e67ce16f68R147-L144) [[12]](diffhunk://#diff-bffe98820c75f17b7530290680a5349d714b873c9fde7051d3b10f272fec2196L1-R103) [[13]](diffhunk://#diff-e659845952c8109aaf2fed0d78e86dc6f8c68076f3e9036132e8180480ffa9f9R138-L148) [[14]](diffhunk://#diff-e659845952c8109aaf2fed0d78e86dc6f8c68076f3e9036132e8180480ffa9f9L179-R179)